### PR TITLE
统一消息发送添加写入kafka

### DIFF
--- a/javamesh-agentcore/javamesh-agentcore-core-ext/pom.xml
+++ b/javamesh-agentcore/javamesh-agentcore-core-ext/pom.xml
@@ -87,6 +87,12 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>2.3.0</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
     <build>
         <finalName>${project.artifactId}-${javamesh.version}</finalName>

--- a/javamesh-agentcore/javamesh-agentcore-core-ext/src/main/java/com/huawei/apm/core/ext/lubanops/transport/kafka/ConfigConst.java
+++ b/javamesh-agentcore/javamesh-agentcore-core-ext/src/main/java/com/huawei/apm/core/ext/lubanops/transport/kafka/ConfigConst.java
@@ -1,0 +1,49 @@
+package com.huawei.apm.core.ext.lubanops.transport.kafka;
+
+public class ConfigConst {
+    /**
+     * kafka配置参数 连接服务端地址
+     */
+    public static final String KAFKA_BOOTSTRAP_SERVERS = "127.0.0.1:9092";
+
+    /**
+     * kafka配置参数 key序列化
+     */
+    public static final String KAFKA_KEY_SERIALIZER = "org.apache.kafka.common.serialization.StringSerializer";
+
+    /**
+     * kafka配置参数 value序列化
+     */
+    public static final String KAFKA_VALUE_SERIALIZER = "org.apache.kafka.common.serialization.StringSerializer";
+
+    /**
+     * kafka配置参数 producer需要server接收到数据之后发出的确认接收的信号 ack 0,1,all
+     */
+    public static final String KAFKA_ACKS = "1";
+
+    /**
+     * kafka配置参数 控制生产者发送请求最大大小,默认1M （这个参数和Kafka主机的message.max.bytes 参数有关系）
+     */
+    public static final String KAFKA_MAX_REQUEST_SIZE = "1048576";
+
+    /**
+     * kafka配置参数 生产者内存缓冲区大小
+     */
+    public static final String KAFKA_BUFFER_MEMORY = "33554432";
+
+    /**
+     * kafka配置参数 重发消息次数
+     */
+    public static final String KAFKA_RETRIES = "0";
+
+    /**
+     * kafka配置参数 客户端将等待请求的响应的最大时间
+     */
+    public static final String KAFKA_REQUEST_TIMEOUT_MS = "10000";
+
+    /**
+     * kafka配置参数 最大阻塞时间，超过则抛出异常
+     */
+    public static final String KAFKA_MAX_BLOCK_MS = "60000";
+}
+

--- a/javamesh-agentcore/javamesh-agentcore-core-ext/src/main/java/com/huawei/apm/core/ext/lubanops/transport/kafka/KafkaClient.java
+++ b/javamesh-agentcore/javamesh-agentcore-core-ext/src/main/java/com/huawei/apm/core/ext/lubanops/transport/kafka/KafkaClient.java
@@ -1,0 +1,28 @@
+package com.huawei.apm.core.ext.lubanops.transport.kafka;
+
+import com.huawei.apm.bootstrap.lubanops.log.LogFactory;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class KafkaClient {
+    private static final Logger LOGGER = LogFactory.getLogger();
+
+    public static void sendMessage(String topic, String msg) {
+        KafkaProducer<String, String> producer = KafkaProducerEnum.KAFKA_PRODUCER.getKafkaProducer();
+
+
+        try {
+            ProducerRecord<String, String> record;
+            record = new ProducerRecord<>(topic, null, msg);
+            producer.send(record, (metadata, exception) -> {
+            });
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "[flowrecord]: send message with kafka failed");
+        } finally {
+            producer.flush();
+        }
+    }
+}

--- a/javamesh-agentcore/javamesh-agentcore-core-ext/src/main/java/com/huawei/apm/core/ext/lubanops/transport/kafka/KafkaConst.java
+++ b/javamesh-agentcore/javamesh-agentcore-core-ext/src/main/java/com/huawei/apm/core/ext/lubanops/transport/kafka/KafkaConst.java
@@ -1,0 +1,43 @@
+package com.huawei.apm.core.ext.lubanops.transport.kafka;
+
+import java.util.Properties;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+
+public class KafkaConst {
+    public static Properties producerConfig() {
+        Properties properties = new Properties();
+        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+                ConfigConst.KAFKA_BOOTSTRAP_SERVERS);
+        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                ConfigConst.KAFKA_KEY_SERIALIZER);
+        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                ConfigConst.KAFKA_VALUE_SERIALIZER);
+
+        // producer需要server接收到数据之后发出的确认接收的信号 ack 0,1,all
+        properties.put(ProducerConfig.ACKS_CONFIG,
+                ConfigConst.KAFKA_ACKS);
+
+        // 控制生产者发送请求最大大小,默认1M （这个参数和Kafka主机的message.max.bytes 参数有关系）
+        properties.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG,
+                ConfigConst.KAFKA_MAX_REQUEST_SIZE);
+
+        // 生产者内存缓冲区大小
+        properties.put(ProducerConfig.BUFFER_MEMORY_CONFIG,
+                ConfigConst.KAFKA_BUFFER_MEMORY);
+
+        // 重发消息次数
+        properties.put(ProducerConfig.RETRIES_CONFIG,
+                ConfigConst.KAFKA_RETRIES);
+
+        // 客户端将等待请求的响应的最大时间
+        properties.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG,
+                ConfigConst.KAFKA_REQUEST_TIMEOUT_MS);
+
+        // 最大阻塞时间，超过则抛出异常
+        properties.put(ProducerConfig.MAX_BLOCK_MS_CONFIG,
+                ConfigConst.KAFKA_MAX_BLOCK_MS);
+
+        return properties;
+    }
+}

--- a/javamesh-agentcore/javamesh-agentcore-core-ext/src/main/java/com/huawei/apm/core/ext/lubanops/transport/kafka/KafkaProducerEnum.java
+++ b/javamesh-agentcore/javamesh-agentcore-core-ext/src/main/java/com/huawei/apm/core/ext/lubanops/transport/kafka/KafkaProducerEnum.java
@@ -1,0 +1,17 @@
+package com.huawei.apm.core.ext.lubanops.transport.kafka;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+
+public enum KafkaProducerEnum {
+    KAFKA_PRODUCER,;
+    private KafkaProducer<String, String> kafkaProducer;
+
+    KafkaProducerEnum() {
+        Thread.currentThread().setContextClassLoader(null);
+        kafkaProducer = new KafkaProducer<>(KafkaConst.producerConfig());
+    }
+
+    public KafkaProducer<String, String> getKafkaProducer() {
+        return KafkaProducerEnum.KAFKA_PRODUCER.kafkaProducer;
+    }
+}


### PR DESCRIPTION
【issue号】#32
【修改原因】
统一消息发送不支持直接写入kafka
【修改内容】
统一消息发送添加直接写入kafka功能
当前配置中kafka配置为单节点
支持topic可配置
【检查者】@fuziye01
【用例描述】暂无用例
【自测情况】自测插件心跳数据通过统一消息发送kafkaClient写入Kafka成功
【影响范围】框架统一消息发送添加直接写入kafka功能