### PR TITLE
设置jsonApi

### DIFF
--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/lubanops/BootStrapImpl.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/lubanops/BootStrapImpl.java
@@ -1,11 +1,13 @@
 package com.huawei.apm.core.lubanops;
 
 import com.huawei.apm.bootstrap.lubanops.agent.AgentInfo;
+import com.huawei.apm.bootstrap.lubanops.api.APIService;
 import com.huawei.apm.bootstrap.lubanops.api.InstrumentationManager;
 import com.huawei.apm.bootstrap.lubanops.config.AgentConfigManager;
 import com.huawei.apm.bootstrap.lubanops.config.IdentityConfigManager;
 import com.huawei.apm.bootstrap.lubanops.log.LogFactory;
 import com.huawei.apm.bootstrap.lubanops.utils.AgentUtils;
+import com.huawei.apm.core.lubanops.api.JSONImpl;
 import com.huawei.apm.core.lubanops.container.AgentServiceContainer;
 import com.huawei.apm.core.lubanops.update.UpdateThread;
 import com.huawei.apm.core.lubanops.utils.AgentPath;
@@ -39,6 +41,7 @@ public class BootStrapImpl {
             IdentityConfigManager.init(argsMap, agentPath.getAgentPath());
             LOGGER.info("----------------------javaagent starting----------------------");
             InstrumentationManager.inst = instrumentation;
+            APIService.setJsonApi(new JSONImpl());
 
             // 设置javaagent启动时间和版本信息
             AgentInfo.setAgentStartTime(System.currentTimeMillis());


### PR DESCRIPTION
【issue号】#63
【修改原因】
框架json接口没有赋值
【修改内容】
框架jsonApi 赋值为JSONImpl实现类
【检查者】@HapThorin @fuziye01
【用例描述】暂无用例
【自测情况】本地测试通过
【影响范围】框架支持json格式处理