### PR TITLE
【bug修复】修复统一配置中使用同一个键解释其值时发生死循环的问题

### DIFF
--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/exception/ConfigDupIndexException.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/exception/ConfigDupIndexException.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved.
+ */
+
+package com.huawei.apm.core.exception;
+
+import java.util.Locale;
+
+/**
+ * 配置重复索引异常，在使用同一个键解释其值时报出，如{@code config.key=prefix.${config.key}.suffix}
+ *
+ * @author HapThorin
+ * @version 1.0.0
+ * @since 2021/11/4
+ */
+public class ConfigDupIndexException extends RuntimeException {
+    public ConfigDupIndexException(String key) {
+        super(String.format(Locale.ROOT, "Unable to use [%s] to explain [%s]. ", key, key));
+    }
+}


### PR DESCRIPTION
【issue号】#73

【修改原因】统一配置中，使用同一个键解释其值时发生死循环

【修改内容】直接抛出异常，而不是任他栈溢出

【检查者】@fuziye01 @3838438abcd @xuezechao-hub

【用例描述】暂无用例

【自测情况】本地测试通过

【影响范围】统一配置系统