### PR TITLE
【新功能】全链路压测sdk支持，增加redis，mongodb。

### DIFF
--- a/javamesh-samples/javamesh-online-stresstest/README.md
+++ b/javamesh-samples/javamesh-online-stresstest/README.md
@@ -8,9 +8,26 @@
 
 业务需要准备stress.properties文件用于制定影子库同正式库的映射关系，并打包到resources中。
 
-示例：
+影子数据库配置示例，该值不能缺省：
+
 key:db 标识配置影子数据库信息，为固定字符串。
 
 value为json串，内容是正式库和影子库的映射关系。内容的key为host:port/dbname的格式，value是影子库的连接信息，用户名和密码同正式库保持一致。
 
 db={"100.100.153.226:3306/stress_test":{"url":"jdbc:mysql://100.100.153.226:3306/_shadow_stress_test?allowMultiQueries=true&useUnicode=true&characterEncoding=utf-8&serverTimezone=GMT"}}
+
+影子redis配置示例, 该值缺省时表示影子数据在同一个redis中，使用shadow_前缀区分：
+
+key:redis.repository 标识配置影子redis信息，为固定字符串。
+
+value为json串，内容是影子redis的地址。内容为json串，默认地址在address中，使用队列格式，如果时master slave模式，需要加上"slave":[]。
+
+redis.repository={"address":["redis://100.100.153.226:6380"]}
+
+影子mogodb配置示例，该值缺省时表示影子数据在同一个mongo database中，使用shadow_前缀的collection区分：
+
+key:mongo.repository 标识配置影子mongo信息，为固定字符串。
+
+value为json串，内容是影子mongodb同原始库的映射信息。内容为json串，key时原始的mongodb数据库名，值是影子mongodb库的信息。
+
+mongo.repository={'stress_test':{'host':'localhost:27017','database':'shadow_stress_test','user_suffix':''}}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/pom.xml
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/pom.xml
@@ -88,10 +88,29 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
+            <version>2.6.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.lettuce</groupId>
+            <artifactId>lettuce-core</artifactId>
+            <version>5.0.1.RELEASE</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver</artifactId>
+            <version>3.12.10</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>transmittable-thread-local</artifactId>
             <version>2.11.4</version>
         </dependency>
+
     </dependencies>
 
 

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/config/Constant.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/config/Constant.java
@@ -13,9 +13,25 @@ package com.lubanops.stresstest.config;
 public interface Constant {
     String DB = "db";
 
-    String TEST_TOPIC = "test.topic";
+    String TEST_TOPIC = "topic";
+
+    String REDIS_KEY = "redis.key";
+
+    String REDIS_REPOSITORY = "redis.repository";
+
+    String MONGO_KEY = "mongo.key";
+
+    String MONGO_REPOSITORY = "mongo.repository";
 
     String SHADOW = "shadow_";
 
     String HTTP_INTERCEPTOR = "com.lubanops.stresstest.http.HttpClientInterceptor";
+    /**
+     * 压测标记key
+     */
+    String TEST_FLAG = "x-test";
+    /**
+     * 压测标记值
+     */
+    String TEST_VALUE = "true";
 }

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/config/bean/MongoSourceInfo.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/config/bean/MongoSourceInfo.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+
+package com.lubanops.stresstest.config.bean;
+
+import com.mongodb.ServerAddress;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 数据库信息
+ *
+ * @author yiwei
+ * @since 2021/10/21
+ */
+public class MongoSourceInfo extends UserInfo {
+    private String host;
+
+    private String database;
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public void setDatabase(String database) {
+        this.database = database;
+    }
+
+    /**
+     * 解析host,生成可用的ServerAddress
+     *
+     * @return mongodb serverAddress 地址
+     */
+    public List<ServerAddress> getAddresses() {
+        List<ServerAddress> addresses = new ArrayList<>();
+        String[] hostArray = getHost().split(",");
+        for (String hostStr : hostArray) {
+            String[] info = hostStr.replace(" ", "").split(":");
+            addresses.add(new ServerAddress(info[0], Integer.parseInt(info[1])));
+        }
+        return addresses;
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/core/Reflection.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/core/Reflection.java
@@ -9,6 +9,10 @@ import com.huawei.apm.core.lubanops.bootstrap.log.LogFactory;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -28,29 +32,29 @@ public class Reflection {
      * @param instance 实例
      * @return 返回值。
      */
-    public static Optional<Object> invokeDeclared(String methodName, Object instance) {
-        if (instance == null) {
-            return Optional.empty();
-        }
-        Class<?> clazz = instance.getClass();
-        Method method;
-        try {
-            method = clazz.getDeclaredMethod(methodName);
-        } catch (NoSuchMethodException e) {
-            LOGGER.severe(String.format("Cannot find method %s.", methodName));
-            return Optional.empty();
-        }
-        return invokeDeclared(method, instance);
+    public static Optional<Object> invokeDeclared(String methodName, Object instance, Object... values) {
+        return getDeclaredMethod(methodName, instance.getClass(), values).map(method -> invokeDeclared(method, instance, values));
     }
 
-    private static Optional<Object> invokeDeclared(Method method, Object instance) {
+    /**
+     * static方法执行。
+     *
+     * @param methodName 方法名
+     * @param className 实例
+     * @return 返回值。
+     */
+    public static Optional<Object> invokeStaticDeclared(String methodName, String className, Object... values) {
+        return getDeclaredMethod(methodName, className, values).map(method -> invokeDeclared(method, null, values));
+    }
+
+    private static Object invokeDeclared(Method method, Object instance, Object... values) {
         accessible(method);
         try {
-            return Optional.ofNullable(method.invoke(instance));
+            return method.invoke(instance, values);
         } catch (Throwable e) {
             LOGGER.severe(String.format("Cannot execute method %s for reason %s.", method.getName(),
                     e.getMessage()));
-            return Optional.empty();
+            return null;
         }
     }
 
@@ -65,7 +69,7 @@ public class Reflection {
         getDeclaredField(fieldName, instance).ifPresent(field -> {
             String value = getDeclaredValueOfString(field, instance);
             if (!Tester.isTestPrefix(value, prefix)) {
-                setDeclaredValue(field, instance, prefix + value);
+                setDeclaredValue(field, instance, prefix + value, false);
             }
         });
     }
@@ -97,18 +101,35 @@ public class Reflection {
      * @param fieldName field name
      * @param instance instance of clazzName
      * @param value the value to be set
+     * @param enableFinal 支持修改final字段
      */
-    public static void setDeclaredValue(String fieldName, Object instance, Object value) {
-        getDeclaredField(fieldName, instance).ifPresent(field -> setDeclaredValue(field, instance, value));
+    public static void setDeclaredValue(String fieldName, Object instance, Object value, boolean enableFinal) {
+        getDeclaredField(fieldName, instance).ifPresent(field -> setDeclaredValue(field, instance, value, enableFinal));
     }
 
-    private static void setDeclaredValue(Field field, Object instance, Object value) {
+    /**
+     * setValue for the specific private field.
+     *
+     * @param fieldName field name
+     * @param instance instance of clazzName
+     * @param value the value to be set
+     */
+    public static void setDeclaredValue(String fieldName, Object instance, Object value) {
+        setDeclaredValue(fieldName, instance, value, false);
+    }
+
+    private static void setDeclaredValue(Field field, Object instance, Object value, boolean enableFinal) {
         String fieldName = field.getName();
         accessible(field);
         try {
+            if (enableFinal) {
+                Field modifiersField = Field.class.getDeclaredField("modifiers");
+                modifiersField.setAccessible(true);
+                modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+            }
             field.set(instance, value);
             LOGGER.fine(String.format("Set value = %s to field %s.", value, fieldName));
-        } catch (IllegalAccessException e) {
+        } catch (NoSuchFieldException | IllegalAccessException e) {
             LOGGER.severe(String.format("Cannot set field %s of class %s.", fieldName,
                     instance.getClass().getName()));
         }
@@ -129,24 +150,91 @@ public class Reflection {
         return "";
     }
 
+    private static Optional<Method> getDeclaredMethod(String methodName, String className, Object... values) {
+        Class<?> clazz;
+        try {
+            clazz = Class.forName(className, true, Thread.currentThread().getContextClassLoader());
+            return getDeclaredMethod(methodName, clazz, values);
+        } catch (ClassNotFoundException e) {
+            LOGGER.severe(String.format("Cannot load %s.", className));
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<Method> getDeclaredMethod(String methodName, Class<?> clazz, Object... value) {
+        List<Class<?>> params = getParameterTypes(value);
+        Method method = null;
+        try {
+            method = getDeclaredMethodOneTime(methodName, clazz, params);
+        } catch (NoSuchMethodException e) {
+            while (true) {
+                clazz = clazz.getSuperclass();
+                if (clazz == Object.class) {
+                    break;
+                }
+                try {
+                    method = getDeclaredMethodOneTime(methodName, clazz, params);
+                } catch (NoSuchMethodException ignored) {
+                    // 故意留白
+                }
+            }
+        }
+        return Optional.ofNullable(method);
+    }
+
+    private static Method getDeclaredMethodOneTime(String methodName, Class<?> clazz, List<Class<?>> params) throws NoSuchMethodException {
+        if (params.isEmpty()) {
+            return clazz.getDeclaredMethod(methodName);
+        } else {
+            return clazz.getDeclaredMethod(methodName, params.toArray(new Class[0]));
+        }
+    }
+
+
+    /**
+     * 获取参数列表的类型。
+     *
+     * @param values 参数列表
+     * @return 类型队列。
+     */
+    private static List<Class<?>> getParameterTypes(Object... values) {
+        List<Class<?>> list = new ArrayList<>();
+        for (Object object : values) {
+            if (object == null) {
+                return Collections.emptyList();
+            } else {
+                list.add(object.getClass());
+            }
+        }
+        return list;
+    }
+
     private static Optional<Field> getDeclaredField(String fieldName, Object instance) {
         Class<?> clazz = instance.getClass();
         try {
             return Optional.of(clazz.getDeclaredField(fieldName));
         } catch (NoSuchFieldException e) {
-            while (clazz != null) {
+            while (true) {
+                clazz = clazz.getSuperclass();
+                if (clazz == Object.class) {
+                    break;
+                }
                 try {
                     return Optional.of(clazz.getDeclaredField(fieldName));
                 } catch (NoSuchFieldException ignored) {
                     // 故意留白
                 }
-                clazz = clazz.getSuperclass();
             }
         }
         return Optional.empty();
     }
 
-    private static void accessible(AccessibleObject object) {
+    /**
+     * 使改对象可访问
+     *
+     * @param object 待修改对象
+     */
+    public static void accessible(AccessibleObject object) {
         if (!object.isAccessible()) {
             object.setAccessible(true);
         }

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/core/Tester.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/core/Tester.java
@@ -7,6 +7,7 @@ package com.lubanops.stresstest.core;
 import com.alibaba.ttl.TransmittableThreadLocal;
 import com.huawei.apm.core.lubanops.bootstrap.utils.StringUtils;
 import com.lubanops.stresstest.config.ConfigFactory;
+import com.sun.org.apache.xalan.internal.xsltc.runtime.StringValueHandler;
 
 import java.util.Locale;
 
@@ -17,14 +18,6 @@ import java.util.Locale;
  * @since 2021/10/21
  */
 public class Tester {
-    /**
-     * 压测标记key
-     */
-    public static final String TEST_FLAG = "x-test";
-    /**
-     * 压测标记值
-     */
-    public static final String TEST_VALUE = "true";
     /**
      * TransmittableThreadLocal 确保除了在本线程内部传递，还能在本地线程之间，本地线程池之间传递。
      */
@@ -66,5 +59,15 @@ public class Tester {
      */
     public static boolean isTestPrefix(String topic, String prefix) {
         return StringUtils.isNotBlank(topic) && topic.toLowerCase(Locale.ROOT).startsWith(prefix);
+    }
+
+    /**
+     * 给mongodb collection增加影子前缀
+     * @param collectionName 原collection
+     * @return 修改后的collection
+     */
+    public static String addTestMongodb(String collectionName) {
+        String prefix = ConfigFactory.getConfig().getTestMongodbPrefix();
+        return isTestPrefix(collectionName, prefix)? collectionName: prefix + collectionName;
     }
 }

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mongodb/MongoCollectionEnhance.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mongodb/MongoCollectionEnhance.java
@@ -2,35 +2,34 @@
  * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
  */
 
-package com.lubanops.stresstest.kafka;
-
+package com.lubanops.stresstest.db.mongodb;
 
 import com.huawei.apm.core.agent.definition.EnhanceDefinition;
 import com.huawei.apm.core.agent.definition.MethodInterceptPoint;
 import com.huawei.apm.core.agent.matcher.ClassMatcher;
 import com.huawei.apm.core.agent.matcher.ClassMatchers;
-
 import net.bytebuddy.matcher.ElementMatchers;
 
 /**
- * KafkaConsumer 增强
+ * Mybatis 增强
  *
  * @author yiwei
- * @since 2021/10/26
+ * @since 2021/10/21
  */
-public class KafkaConsumerEnhance implements EnhanceDefinition {
-    private static final String ENHANCE_CLASS = "org.springframework.kafka.core.DefaultKafkaConsumerFactory";
-    private static final String INTERCEPT_CLASS = "com.lubanops.stresstest.kafka.KafkaConsumerInterceptor";
+public class MongoCollectionEnhance implements EnhanceDefinition {
+    private static final String OLD_ENHANCE_CLASS = "com.mongodb.DB";
+    private static final String NEW_ENHANCE_CLASS = "com.mongodb.client.internal.MongoDatabaseImpl";
+    private static final String INTERCEPT_CLASS = "com.lubanops.stresstest.db.mongodb.MongoCollectionInterceptor";
 
     @Override
     public ClassMatcher enhanceClass() {
-        return ClassMatchers.named(ENHANCE_CLASS);
+        return ClassMatchers.multiClass(OLD_ENHANCE_CLASS, NEW_ENHANCE_CLASS);
     }
 
     @Override
     public MethodInterceptPoint[] getMethodInterceptPoints() {
         return new MethodInterceptPoint[]{MethodInterceptPoint.newInstMethodInterceptPoint(INTERCEPT_CLASS,
-                ElementMatchers.named("createConsumer"))
+                ElementMatchers.named("getCollection"))
         };
     }
 }

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mongodb/MongoCollectionInterceptor.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mongodb/MongoCollectionInterceptor.java
@@ -1,31 +1,35 @@
 /*
  * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
  */
-package com.lubanops.stresstest.kafka;
+
+package com.lubanops.stresstest.db.mongodb;
 
 import com.huawei.apm.core.agent.common.BeforeResult;
 import com.huawei.apm.core.agent.interceptor.InstanceMethodInterceptor;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
+import com.lubanops.stresstest.config.ConfigFactory;
+import com.lubanops.stresstest.core.Tester;
 
 import java.lang.reflect.Method;
 
+import static com.lubanops.stresstest.core.Tester.addTestMongodb;
+
 /**
- * KafkaConsumer 增强实现
+ * Mongo collection 增强实现
  *
  * @author yiwei
- * @since 2021/10/27
+ * @since 2021/10/21
  */
-public class KafkaConsumerInterceptor implements InstanceMethodInterceptor {
+public class MongoCollectionInterceptor implements InstanceMethodInterceptor {
     @Override
     public void before(Object obj, Method method, Object[] arguments, BeforeResult beforeResult) {
+        if (Tester.isTest() && !ConfigFactory.getConfig().isMongoShadowRepositories() ) {
+            arguments[0] = addTestMongodb((String) arguments[0]);
+        }
     }
 
     @Override
     public Object after(Object obj, Method method, Object[] arguments, Object result) {
-        if (result instanceof ShadowConsumer) {
-            return result;
-        }
-        return new ShadowConsumer<>((KafkaConsumer<?, ?>)result);
+        return result;
     }
 
     @Override

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mongodb/MongoDatabaseEnhance.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mongodb/MongoDatabaseEnhance.java
@@ -2,35 +2,34 @@
  * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
  */
 
-package com.lubanops.stresstest.kafka;
-
+package com.lubanops.stresstest.db.mongodb;
 
 import com.huawei.apm.core.agent.definition.EnhanceDefinition;
 import com.huawei.apm.core.agent.definition.MethodInterceptPoint;
 import com.huawei.apm.core.agent.matcher.ClassMatcher;
 import com.huawei.apm.core.agent.matcher.ClassMatchers;
-
 import net.bytebuddy.matcher.ElementMatchers;
 
 /**
- * KafkaConsumer 增强
+ * Mybatis 增强
  *
  * @author yiwei
- * @since 2021/10/26
+ * @since 2021/10/21
  */
-public class KafkaConsumerEnhance implements EnhanceDefinition {
-    private static final String ENHANCE_CLASS = "org.springframework.kafka.core.DefaultKafkaConsumerFactory";
-    private static final String INTERCEPT_CLASS = "com.lubanops.stresstest.kafka.KafkaConsumerInterceptor";
+public class MongoDatabaseEnhance implements EnhanceDefinition {
+    private static final String OLD_ENHANCE_CLASS = "com.mongodb.MongoClient";
+    private static final String NEW_ENHANCE_CLASS = "com.mongodb.client.internal.MongoClientImpl";
+    private static final String INTERCEPT_CLASS = "com.lubanops.stresstest.db.mongodb.MongoDatabaseInterceptor";
 
     @Override
     public ClassMatcher enhanceClass() {
-        return ClassMatchers.named(ENHANCE_CLASS);
+        return ClassMatchers.multiClass(OLD_ENHANCE_CLASS, NEW_ENHANCE_CLASS);
     }
 
     @Override
     public MethodInterceptPoint[] getMethodInterceptPoints() {
         return new MethodInterceptPoint[]{MethodInterceptPoint.newInstMethodInterceptPoint(INTERCEPT_CLASS,
-                ElementMatchers.named("createConsumer"))
+                ElementMatchers.named("getDatabase"))
         };
     }
 }

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mongodb/MongoDatabaseInterceptor.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mongodb/MongoDatabaseInterceptor.java
@@ -1,31 +1,33 @@
 /*
  * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
  */
-package com.lubanops.stresstest.kafka;
+
+package com.lubanops.stresstest.db.mongodb;
 
 import com.huawei.apm.core.agent.common.BeforeResult;
 import com.huawei.apm.core.agent.interceptor.InstanceMethodInterceptor;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
+import com.lubanops.stresstest.config.ConfigFactory;
+import com.lubanops.stresstest.core.Tester;
 
 import java.lang.reflect.Method;
 
 /**
- * KafkaConsumer 增强实现
+ * Mongo database 增强实现
  *
  * @author yiwei
- * @since 2021/10/27
+ * @since 2021/10/21
  */
-public class KafkaConsumerInterceptor implements InstanceMethodInterceptor {
+public class MongoDatabaseInterceptor implements InstanceMethodInterceptor {
     @Override
     public void before(Object obj, Method method, Object[] arguments, BeforeResult beforeResult) {
     }
 
     @Override
     public Object after(Object obj, Method method, Object[] arguments, Object result) {
-        if (result instanceof ShadowConsumer) {
-            return result;
+        if (Tester.isTest() && ConfigFactory.getConfig().isMongoShadowRepositories() ) {
+            return ShadowMongodb.getInstance().getShadowDatabaseFromClient(obj, (String) arguments[0]);
         }
-        return new ShadowConsumer<>((KafkaConsumer<?, ?>)result);
+        return result;
     }
 
     @Override

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mongodb/ShadowMongodb.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mongodb/ShadowMongodb.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+package com.lubanops.stresstest.db.mongodb;
+
+import com.huawei.apm.core.lubanops.bootstrap.log.LogFactory;
+import com.lubanops.stresstest.config.ConfigFactory;
+import com.lubanops.stresstest.config.bean.MongoSourceInfo;
+import com.lubanops.stresstest.core.Reflection;
+import com.mongodb.AuthenticationMechanism;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoCredential;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.internal.MongoClientImpl;
+import com.mongodb.client.internal.MongoDatabaseImpl;
+import com.mongodb.client.internal.OperationExecutor;
+import com.mongodb.connection.ClusterSettings;
+import org.bson.codecs.configuration.CodecRegistry;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
+
+/**
+ * 影子Mongodb
+ *
+ * @author yiwei
+ * @since 2021/11/4
+ */
+public class ShadowMongodb {
+    private static final Map<String, Object> SHADOW_CLIENTS = new ConcurrentHashMap<>();
+    private static final Logger LOGGER = LogFactory.getLogger();
+    private static final ShadowMongodb INSTANCE = new ShadowMongodb();
+
+    private ShadowMongodb() { }
+
+    public static ShadowMongodb getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * 根据原始的client， databasename 返回影子的client。如果返回的client有效，把原始的databasename-> client映射放到map中供后续使用。
+     *
+     * @param mongoClient 原始的clint
+     * @param database 原始的database名字
+     * @return 影子database。
+     */
+    public MongoDatabase getShadowDatabaseFromClient(Object mongoClient, String database) {
+        MongoSourceInfo info = ConfigFactory.getConfig().getShadowMongoSourceInfo(database);
+        if (mongoClient instanceof MongoClient) {
+            MongoClient client = newShadowOldMongoClient((MongoClient) mongoClient, database, info);
+            MongoClientOptions clientOptions = client.getMongoClientOptions();
+            return new MongoDatabaseImpl(info.getDatabase(), (CodecRegistry) Objects.requireNonNull(
+                    Reflection.invokeDeclared("getCodecRegistry", client).orElse(null)),
+                    clientOptions.getReadPreference(), clientOptions.getWriteConcern(), clientOptions.getRetryWrites(),
+                    clientOptions.getRetryReads(), clientOptions.getReadConcern(), clientOptions.getUuidRepresentation(),
+                    (OperationExecutor) Objects.requireNonNull(
+                            Reflection.invokeDeclared("createOperationExecutor", client).orElse(null)));
+        } else if (mongoClient instanceof MongoClientImpl) {
+            MongoClientImpl client = newShadowNewMongoClient((MongoClientImpl) mongoClient, database, info);
+            return Reflection.getDeclaredValue("settings", client).map(settings -> {
+                if (settings instanceof MongoClientSettings) {
+                    return new MongoDatabaseImpl(info.getDatabase(), client.getCodecRegistry(),
+                            ((MongoClientSettings)settings).getReadPreference(),
+                            ((MongoClientSettings)settings).getWriteConcern(),
+                            ((MongoClientSettings)settings).getRetryWrites(),
+                            ((MongoClientSettings)settings).getRetryReads(),
+                            ((MongoClientSettings)settings).getReadConcern(),
+                            ((MongoClientSettings)settings).getUuidRepresentation(),
+                            (OperationExecutor) Objects.requireNonNull(Reflection.getDeclaredValue("delegate", client)
+                                    .flatMap(delegate -> Reflection.invokeDeclared("getOperationExecutor", delegate))
+                                    .orElse(null)));
+                }
+                return null;
+            }).orElse(null);
+            } else {
+            LOGGER.severe(String.format("Unknown mongoClient %s", mongoClient.getClass().getName()));
+        }
+        return null;
+    }
+
+    /**
+     * 返回新版本的影子MongoClient
+     *
+     * @param client mongocleint
+     * @param database database
+     * @return shadow client
+     */
+    private MongoClientImpl newShadowNewMongoClient(MongoClientImpl client, String database, MongoSourceInfo info) {
+        if (SHADOW_CLIENTS.containsKey(database)) {
+            return (MongoClientImpl) SHADOW_CLIENTS.get(database);
+        } else {
+            ClusterSettings clusterSettings = client.getCluster().getSettings();
+            final ClusterSettings.Builder clusterBuilder = ClusterSettings.builder(clusterSettings);
+
+            clusterBuilder.hosts(info.getAddresses());
+            MongoClientSettings.Builder clientBuilders = Reflection.getDeclaredValue("settings", client).map(settings
+                    -> getFromSettings(settings, info, database)).orElse(MongoClientSettings.builder());
+            clientBuilders.applyToClusterSettings(builder -> builder.applySettings(clusterBuilder.build()));
+            com.mongodb.client.MongoClient shadowClient =  MongoClients.create(clientBuilders.build());
+            SHADOW_CLIENTS.put(database, shadowClient);
+            return (MongoClientImpl) shadowClient;
+        }
+    }
+
+    private MongoClientSettings.Builder getFromSettings(Object settings, MongoSourceInfo info, String database) {
+        MongoClientSettings.Builder clientBuilders;
+        if (settings instanceof MongoClientSettings) {
+            MongoClientSettings clientSettings = (MongoClientSettings) settings;
+            clientBuilders = MongoClientSettings.builder(clientSettings);
+            MongoCredential credential = clientSettings.getCredential();
+            if (credential != null) {
+                MongoCredential shadowCredential = createShadowCredential(credential, database, info);
+                clientBuilders.credential(shadowCredential);
+            }
+        } else {
+            clientBuilders = MongoClientSettings.builder();
+        }
+        return clientBuilders;
+    }
+
+    /**
+     * 返回老版本的影子MongoClient
+     *
+     * @param client mongocleint
+     * @param database database
+     * @return shadow client
+     */
+    private MongoClient newShadowOldMongoClient(MongoClient client, String database, MongoSourceInfo info) {
+        if (SHADOW_CLIENTS.containsKey(database)) {
+            return (MongoClient) SHADOW_CLIENTS.get(database);
+        } else {
+            List<MongoCredential> credentials = client.getCredentialsList();
+            MongoClientOptions clientOptions = client.getMongoClientOptions();
+            MongoClient shadowClient;
+            if (credentials.size() > 0) {
+                MongoCredential credential = createShadowCredential(credentials.get(0), database, info);
+                shadowClient = new MongoClient(info.getAddresses(), credential, clientOptions);
+            } else {
+                shadowClient = new MongoClient(info.getAddresses(), clientOptions);
+            }
+            SHADOW_CLIENTS.put(database, shadowClient);
+            return shadowClient;
+        }
+    }
+
+    private MongoCredential createShadowCredential(MongoCredential credential, String originDatabase, MongoSourceInfo info) {
+        StringBuilder builder = new StringBuilder();
+        if (info.getUserPrefix() != null) {
+            builder.append(info.getUserPrefix());
+        }
+        builder.append(credential.getUserName());
+        if (info.getUserSuffix() != null) {
+            builder.append(info.getUserSuffix());
+        }
+        AuthenticationMechanism mechanism = credential.getAuthenticationMechanism();
+        String database;
+        if (originDatabase.equalsIgnoreCase(credential.getSource())) {
+            database = info.getDatabase();
+        } else {
+            database = credential.getSource();
+        }
+        if (mechanism == null) {
+            return MongoCredential.createCredential(builder.toString(), database, credential.getPassword());
+        }
+        switch (mechanism) {
+            case PLAIN:
+                return MongoCredential.createPlainCredential(builder.toString(), database, credential.getPassword());
+            case SCRAM_SHA_1:
+                return MongoCredential.createScramSha1Credential(builder.toString(), database,
+                        credential.getPassword());
+            case SCRAM_SHA_256:
+                return MongoCredential.createScramSha256Credential(builder.toString(), database,
+                        credential.getPassword());
+            case GSSAPI:
+                return MongoCredential.createGSSAPICredential(builder.toString());
+            case MONGODB_X509:
+                return MongoCredential.createMongoX509Credential(builder.toString());
+            case MONGODB_CR:
+                return MongoCredential.createMongoCRCredential(builder.toString(), database, credential.getPassword());
+        }
+        return credential;
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/http/HttpClientInterceptor.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/http/HttpClientInterceptor.java
@@ -13,8 +13,8 @@ import org.apache.http.HttpRequest;
 import java.lang.reflect.Method;
 import java.util.logging.Logger;
 
-import static com.lubanops.stresstest.core.Tester.TEST_FLAG;
-import static com.lubanops.stresstest.core.Tester.TEST_VALUE;
+import static com.lubanops.stresstest.config.Constant.TEST_FLAG;
+import static com.lubanops.stresstest.config.Constant.TEST_VALUE;
 
 /**
  * HttpClient 拦截器，如果是压测线程发送请求时，则在头部加上压测字段

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/kafka/KafkaProducerInterceptor.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/kafka/KafkaProducerInterceptor.java
@@ -13,8 +13,8 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import java.lang.reflect.Method;
 
 import static com.lubanops.stresstest.core.Reflection.*;
-import static com.lubanops.stresstest.core.Tester.TEST_FLAG;
-import static com.lubanops.stresstest.core.Tester.TEST_VALUE;
+import static com.lubanops.stresstest.config.Constant.TEST_FLAG;
+import static com.lubanops.stresstest.config.Constant.TEST_VALUE;
 
 /**
  * KafkaProducer 增强实现

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/kafka/ShadowConsumer.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/kafka/ShadowConsumer.java
@@ -94,18 +94,18 @@ public class ShadowConsumer<K, V> implements Consumer<K, V> {
     }
 
     private ConsumerRecords originalPoll(Duration timeout) {
+        Tester.setTest(false);
         ConsumerRecords records = originalConsumer.poll(timeout);
         if (records.count() < SIZE) {
             useOriginal = false;
         }
-        Tester.setTest(false);
         return records;
     }
 
     private ConsumerRecords testPoll(Duration timeout) {
+        Tester.setTest(true);
         ConsumerRecords records = testConsumer.poll(timeout);
         useOriginal = true;
-        Tester.setTest(true);
         return records;
     }
 

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/RedisUtils.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/RedisUtils.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+
+package com.lubanops.stresstest.redis;
+
+import com.huawei.apm.core.lubanops.bootstrap.log.LogFactory;
+import com.huawei.apm.core.lubanops.bootstrap.utils.StringUtils;
+import com.lubanops.stresstest.config.ConfigFactory;
+
+import java.io.UnsupportedEncodingException;
+import java.util.*;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Redis 拦截器，修改key值，增加shadow前缀。
+ *
+ * @author yiwei
+ * @since 2021/11/1
+ */
+public class RedisUtils {
+    private static final String PATTERN = "(redis://)*([A-Za-z0-9.]+:*\\d*?$)";
+    private static final String KEY = ConfigFactory.getConfig().getTestRedisPrefix();
+    private static final Logger LOGGER = LogFactory.getLogger();
+    private static final String DEFAULT_CHARSET = "UTF-8";
+    private static final String ADDRESS = "address";
+    private static final String SLAVE = "slave";
+
+    /**
+     *
+     * @return jedis的连接信息，区别在于没有前面的redis://
+     */
+    public static String getJedisAddress() {
+        return getRedisAddress(ADDRESS,2).get(0);
+    }
+
+    /**
+     *
+     * @return 首个redis address的值
+     */
+    public static String getMasterAddress() {
+        return getRedisAddress(ADDRESS,0).get(0);
+    }
+
+    /**
+     *
+     * @return redis address的所有值。
+     */
+    public static List<String> getNodeAddress() {
+        return getRedisAddress(ADDRESS,0);
+    }
+
+    /**
+     *
+     * @return slave 地址
+     */
+    public static Set<String> getSalveRedisAddress() {
+        return new HashSet<>(getRedisAddress(SLAVE, 0));
+    }
+
+    private static List<String> getRedisAddress(String name, int index) {
+        Object addresses = ConfigFactory.getConfig().getShadowRedis().get(name);
+        Pattern pattern = Pattern.compile(PATTERN);
+        if (addresses instanceof List<?> && ((List<?>) addresses).size() > 0) {
+            List<String> list = new ArrayList<>();
+            for (Object address: (List<?>)addresses) {
+                Matcher matcher = pattern.matcher(address.toString());
+                if (matcher.find()) {
+                    list.add(matcher.group(index));
+                }
+            }
+            return list;
+        }
+        return addresses==null? Collections.emptyList() :
+                Collections.singletonList(addresses.toString());
+    }
+
+    /**
+     * 修改单个key或者collection， 加上影子前缀
+     * @param key 要修改的key
+     * @return 修改后的key
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T modifyKey(final T key) {
+        if (key instanceof Iterable) {
+            return (T) modifyIterable((Iterable<?>) key);
+        }
+        if (key != null && key.getClass().isArray()) {
+            return (T) modifyArray((Object[]) key);
+        }
+        return modifySingleKey(key);
+    }
+
+    /**
+     * 修改单个key， 加上影子前缀
+     * @param key 要修改的key
+     * @return 修改后的key
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T modifySingleKey(final T key) {
+        if (key instanceof String) {
+            return (T) modifyString((String) key);
+        }
+        if (key instanceof byte[]) {
+            return (T) modifyBytes((byte[]) key);
+        }
+        return key;
+    }
+
+    /**
+     * 修改bytes， 加上影子前缀
+     * @param key 要修改的key
+     * @return 修改后的key
+     */
+    public static byte[] modifyBytes(final byte[] key) {
+        try {
+            String str = new String(key, DEFAULT_CHARSET);
+            return modifyKey(str).getBytes(DEFAULT_CHARSET);
+        } catch (UnsupportedEncodingException e) {
+            LOGGER.severe("Don't support UTF-8.");
+        }
+        return key;
+    }
+
+    /**
+     * 修改String， 加上影子前缀
+     * @param key 要修改的key
+     * @return 修改后的key
+     */
+    public static String modifyString(final String key) {
+        return StringUtils.isNotBlank(key) && !key.startsWith(KEY) ? KEY + key : key;
+    }
+
+    private static <T> Iterable<T> modifyIterable(final Iterable<T> keys) {
+        List<T> results = new ArrayList<>();
+        for (T key: keys) {
+            results.add(modifySingleKey(key));
+        }
+        return results;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T[] modifyArray(final T[] keys) {
+        int length = keys.length;
+        T[] results = (T[])new Object[length];
+        for (int i = 0; i< length; i++) {
+            results[i] = modifySingleKey(keys[i]);
+        }
+        return results;
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/JedisClusterCRCEnhance.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/JedisClusterCRCEnhance.java
@@ -1,0 +1,31 @@
+package com.lubanops.stresstest.redis.jedis;
+
+import com.huawei.apm.core.agent.definition.EnhanceDefinition;
+import com.huawei.apm.core.agent.definition.MethodInterceptPoint;
+import com.huawei.apm.core.agent.matcher.ClassMatcher;
+import com.huawei.apm.core.agent.matcher.ClassMatchers;
+import net.bytebuddy.matcher.ElementMatchers;
+
+/**
+ * Jedis cluster CRC 增强
+ *
+ * @author yiwei
+ * @since 2021/11/1
+ */
+public class JedisClusterCRCEnhance implements EnhanceDefinition {
+    private static final String OLD_ENHANCE_CLASS = "redis.clients.util.JedisClusterCRC16";
+    private static final String NEW_ENHANCE_CLASS = "redis.clients.jedis.util.JedisClusterCRC16";
+    private static final String INTERCEPT_CLASS = "com.lubanops.stresstest.redis.jedis.JedisClusterInterceptor";
+
+    @Override
+    public ClassMatcher enhanceClass() {
+        return ClassMatchers.multiClass(OLD_ENHANCE_CLASS, NEW_ENHANCE_CLASS);
+    }
+
+    @Override
+    public MethodInterceptPoint[] getMethodInterceptPoints() {
+        return new MethodInterceptPoint[]{MethodInterceptPoint.newStaticMethodInterceptPoint(INTERCEPT_CLASS,
+                ElementMatchers.named("getSlot"))
+        };
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/JedisClusterInterceptor.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/JedisClusterInterceptor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+
+package com.lubanops.stresstest.redis.jedis;
+
+import com.huawei.apm.core.agent.common.BeforeResult;
+import com.huawei.apm.core.agent.interceptor.StaticMethodInterceptor;
+import com.lubanops.stresstest.config.ConfigFactory;
+import com.lubanops.stresstest.core.Tester;
+import com.lubanops.stresstest.redis.RedisUtils;
+
+import java.lang.reflect.Method;
+
+/**
+ * Jedis Cluster 拦截器，修改getSlot方法。
+ *
+ * @author yiwei
+ * @since 2021/10/21
+ */
+public class JedisClusterInterceptor implements StaticMethodInterceptor {
+    @Override
+    public void before(Class<?> clazz, Method method, Object[] arguments, BeforeResult beforeResult) {
+        if (Tester.isTest() && !ConfigFactory.getConfig().isRedisShadowRepositories() && arguments.length > 0 ) {
+            arguments[0] = RedisUtils.modifySingleKey(arguments[0]);
+        }
+    }
+
+    @Override
+    public Object after(Class<?> clazz, Method method, Object[] arguments, Object result) {
+        return result;
+    }
+
+    @Override
+    public void onThrow(Class<?> clazz, Method method, Object[] arguments, Throwable throwable) {
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/JedisKeyEnhance.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/JedisKeyEnhance.java
@@ -1,26 +1,20 @@
-/*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
- */
-
-package com.lubanops.stresstest.kafka;
-
+package com.lubanops.stresstest.redis.jedis;
 
 import com.huawei.apm.core.agent.definition.EnhanceDefinition;
 import com.huawei.apm.core.agent.definition.MethodInterceptPoint;
 import com.huawei.apm.core.agent.matcher.ClassMatcher;
 import com.huawei.apm.core.agent.matcher.ClassMatchers;
-
 import net.bytebuddy.matcher.ElementMatchers;
 
 /**
- * KafkaConsumer 增强
+ * Jedis 增强
  *
  * @author yiwei
- * @since 2021/10/26
+ * @since 2021/11/1
  */
-public class KafkaConsumerEnhance implements EnhanceDefinition {
-    private static final String ENHANCE_CLASS = "org.springframework.kafka.core.DefaultKafkaConsumerFactory";
-    private static final String INTERCEPT_CLASS = "com.lubanops.stresstest.kafka.KafkaConsumerInterceptor";
+public class JedisKeyEnhance implements EnhanceDefinition {
+    private static final String ENHANCE_CLASS = "redis.clients.jedis.Connection";
+    private static final String INTERCEPT_CLASS = "com.lubanops.stresstest.redis.jedis.JedisKeyInterceptor";
 
     @Override
     public ClassMatcher enhanceClass() {
@@ -30,7 +24,7 @@ public class KafkaConsumerEnhance implements EnhanceDefinition {
     @Override
     public MethodInterceptPoint[] getMethodInterceptPoints() {
         return new MethodInterceptPoint[]{MethodInterceptPoint.newInstMethodInterceptPoint(INTERCEPT_CLASS,
-                ElementMatchers.named("createConsumer"))
+                ElementMatchers.named("sendCommand"))
         };
     }
 }

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/JedisKeyInterceptor.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/JedisKeyInterceptor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+
+package com.lubanops.stresstest.redis.jedis;
+
+import com.huawei.apm.core.agent.common.BeforeResult;
+import com.huawei.apm.core.agent.interceptor.InstanceMethodInterceptor;
+import com.lubanops.stresstest.config.ConfigFactory;
+import com.lubanops.stresstest.core.Tester;
+import com.lubanops.stresstest.redis.jedis.command.HandlerFactory;
+
+import java.lang.reflect.Method;
+
+/**
+ * Jedis Cluster 拦截器，修改getSlot方法。
+ *
+ * @author yiwei
+ * @since 2021/10/21
+ */
+public class JedisKeyInterceptor implements InstanceMethodInterceptor {
+    @Override
+    public void before(Object obj, Method method, Object[] arguments, BeforeResult beforeResult) {
+        if (Tester.isTest() && !ConfigFactory.getConfig().isRedisShadowRepositories() && arguments.length > 1 &&
+                arguments[1] instanceof byte[][]) {
+            arguments[1] = HandlerFactory.getHandler(arguments[0]).handle((byte[][])arguments[1]);
+        }
+    }
+
+    @Override
+    public Object after(Object obj, Method method, Object[] arguments, Object result) {
+        return result;
+    }
+
+    @Override
+    public void onThrow(Object obj, Method method, Object[] arguments, Throwable throwable) {
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/JedisPoolEnhance.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/JedisPoolEnhance.java
@@ -1,26 +1,20 @@
-/*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
- */
-
-package com.lubanops.stresstest.kafka;
-
+package com.lubanops.stresstest.redis.jedis;
 
 import com.huawei.apm.core.agent.definition.EnhanceDefinition;
 import com.huawei.apm.core.agent.definition.MethodInterceptPoint;
 import com.huawei.apm.core.agent.matcher.ClassMatcher;
 import com.huawei.apm.core.agent.matcher.ClassMatchers;
-
 import net.bytebuddy.matcher.ElementMatchers;
 
 /**
- * KafkaConsumer 增强
+ * Jedis pool增强
  *
  * @author yiwei
- * @since 2021/10/26
+ * @since 2021/11/3
  */
-public class KafkaConsumerEnhance implements EnhanceDefinition {
-    private static final String ENHANCE_CLASS = "org.springframework.kafka.core.DefaultKafkaConsumerFactory";
-    private static final String INTERCEPT_CLASS = "com.lubanops.stresstest.kafka.KafkaConsumerInterceptor";
+public class JedisPoolEnhance implements EnhanceDefinition {
+    private static final String ENHANCE_CLASS = "redis.clients.jedis.JedisPool";
+    private static final String INTERCEPT_CLASS = "com.lubanops.stresstest.redis.jedis.JedisPoolInterceptor";
 
     @Override
     public ClassMatcher enhanceClass() {
@@ -30,7 +24,7 @@ public class KafkaConsumerEnhance implements EnhanceDefinition {
     @Override
     public MethodInterceptPoint[] getMethodInterceptPoints() {
         return new MethodInterceptPoint[]{MethodInterceptPoint.newInstMethodInterceptPoint(INTERCEPT_CLASS,
-                ElementMatchers.named("createConsumer"))
+                ElementMatchers.named("getResource"))
         };
     }
 }

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/JedisPoolInterceptor.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/JedisPoolInterceptor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+
+package com.lubanops.stresstest.redis.jedis;
+
+import com.huawei.apm.core.agent.common.BeforeResult;
+import com.huawei.apm.core.agent.interceptor.InstanceMethodInterceptor;
+import com.huawei.apm.core.lubanops.bootstrap.log.LogFactory;
+import com.lubanops.stresstest.config.ConfigFactory;
+import com.lubanops.stresstest.core.Reflection;
+import com.lubanops.stresstest.core.Tester;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.logging.Logger;
+
+/**
+ * Jedis pool 拦截器，返回影子redis 连接。
+ *
+ * @author yiwei
+ * @since 2021/10/21
+ */
+public class JedisPoolInterceptor implements InstanceMethodInterceptor {
+    private static final Logger LOGGER = LogFactory.getLogger();
+
+    @Override
+    public void before(Object obj, Method method, Object[] arguments, BeforeResult beforeResult) {
+    }
+
+    @Override
+    public Object after(Object obj, Method method, Object[] arguments, Object result) {
+        if (!Tester.isTest() || !ConfigFactory.getConfig().isRedisShadowRepositories()) {
+            return result;
+        }
+        if (ShadowJedisFactory.getInstance().isShadowClient(result)) {
+            return result;
+        }
+        Object shadowPool = ShadowJedisFactory.getInstance().getShadowPool(obj);
+        if (shadowPool == null) {
+            return result;
+        }
+        try {
+            Object shadowJedis = method.invoke(shadowPool);
+            Reflection.invokeDeclared("close", result);
+            return shadowJedis;
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            LOGGER.severe("Cannot new shadow jedis from pool.");
+        }
+        return result;
+    }
+
+    @Override
+    public void onThrow(Object obj, Method method, Object[] arguments, Throwable throwable) {
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/ShadowJedisFactory.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/ShadowJedisFactory.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+package com.lubanops.stresstest.redis.jedis;
+
+import com.huawei.apm.core.lubanops.bootstrap.log.LogFactory;
+import com.lubanops.stresstest.core.Reflection;
+import com.lubanops.stresstest.redis.RedisUtils;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.logging.Logger;
+
+/**
+ * 影子Jedis 工厂
+ *
+ * @author yiwei
+ * @since 2021/11/4
+ */
+public class ShadowJedisFactory {
+    private static final Logger LOGGER = LogFactory.getLogger();
+    private final String shadowHostAndPort;
+    private volatile Object shadowPool;
+    private final ReentrantLock lock;
+
+    private static final ShadowJedisFactory INSTANCE = new ShadowJedisFactory();
+
+    private ShadowJedisFactory() {
+        shadowHostAndPort = RedisUtils.getJedisAddress();
+        lock = new ReentrantLock();
+    }
+
+    /**
+     * 单例模式
+     *
+     * @return 影子jedis factory
+     */
+    public static ShadowJedisFactory getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * 获取影子的 jedis pool
+     *
+     * @param jedisPool 原始的jedis pool
+     * @return 影子jedis pool
+     */
+    public Object getShadowPool(Object jedisPool) {
+        if (shadowPool == null) {
+            lock.lock();
+            try {
+                if (shadowPool == null) {
+                    shadowPool = getSetShadowJedisPool(jedisPool).orElse(null);
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
+        return shadowPool;
+    }
+
+    /**
+     * 查询当前的jedis是否是影子的redis
+     *
+     * @param jedis 待检查的redis
+     * @return 如果是影子redis返回true，否则返回false
+     */
+    public boolean isShadowClient(Object jedis) {
+        StringBuilder builder = new StringBuilder();
+        if (jedis == null) {
+            return true;
+        }
+        Reflection.invokeDeclared("getClient", jedis).ifPresent(client -> {
+            builder.append(Reflection.invokeDeclared("getHost", client).orElse(""));
+            builder.append(":");
+            builder.append(Reflection.invokeDeclared("getPort", client).orElse(""));
+        });
+        return shadowHostAndPort.contains(builder.toString());
+    }
+
+    private Optional<Object> getSetShadowJedisPool(Object jedisPool) {
+        Class<?> clazz = jedisPool.getClass();
+        try {
+            final Object shadowJedisPool = clazz.newInstance();
+            Reflection.getDeclaredValue("internalPool", shadowJedisPool)
+                    .ifPresent(internalShadowPool -> Reflection.getDeclaredValue("internalPool", jedisPool)
+                            .ifPresent(internalPool ->
+                                    setInternalShadowPool(internalPool, internalShadowPool, shadowHostAndPort)));
+            return Optional.of(shadowJedisPool);
+        } catch (InstantiationException | IllegalAccessException e) {
+            LOGGER.severe("Cannot new shadow jedis pool.");
+        }
+        return Optional.empty();
+    }
+
+    private void setInternalShadowPool(Object internalPool, Object internalShadowPool, String shadowHostAndPort) {
+        Reflection.getDeclaredValue("factory", internalPool).ifPresent(factory ->
+                Reflection.getDeclaredValue("factory", internalShadowPool).ifPresent(shadowFactory -> {
+                    setShadowFactory(factory, shadowFactory, shadowHostAndPort);
+                    copyPool(internalPool, internalShadowPool);
+                }));
+    }
+
+    private void setShadowFactory(Object factory, Object shadowFactory, String shadowHostAndPort) {
+        Reflection.getDeclaredValue("connectionTimeout", factory).ifPresent(value ->
+                Reflection.setDeclaredValue("connectionTimeout", shadowFactory, value));
+
+        Reflection.getDeclaredValue("soTimeout", factory).ifPresent(value ->
+                Reflection.setDeclaredValue("soTimeout", shadowFactory, value));
+
+        Reflection.getDeclaredValue("password", factory).ifPresent(value ->
+                Reflection.setDeclaredValue("password", shadowFactory, value));
+
+        Reflection.getDeclaredValue("database", factory).ifPresent(value ->
+                Reflection.setDeclaredValue("database", shadowFactory, value));
+
+        Reflection.getDeclaredValue("clientName", factory).ifPresent(value ->
+                Reflection.setDeclaredValue("clientName", shadowFactory, value));
+
+        Reflection.getDeclaredValue("user", factory).ifPresent(value ->
+                Reflection.setDeclaredValue("user", shadowFactory, value));
+
+        Reflection.getDeclaredValue("ssl", factory).ifPresent(value ->
+                Reflection.setDeclaredValue("ssl", shadowFactory, value));
+
+        Reflection.getDeclaredValue("sslSocketFactory", factory).ifPresent(value ->
+                Reflection.setDeclaredValue("sslSocketFactory", shadowFactory, value));
+
+        Reflection.getDeclaredValue("sslParameters", factory).ifPresent(value ->
+                Reflection.setDeclaredValue("sslParameters", shadowFactory, value));
+
+        Reflection.getDeclaredValue("hostnameVerifier", factory).ifPresent(value ->
+                Reflection.setDeclaredValue("hostnameVerifier", shadowFactory, value));
+
+        Reflection.getDeclaredValue("hostAndPort", shadowFactory).ifPresent(hostAndPort -> {
+            if (hostAndPort instanceof AtomicReference) {
+                AtomicReference<?> ref = (AtomicReference<?>)hostAndPort;
+                Object value = ref.get();
+                String[] shadowAddressInfos = shadowHostAndPort.split(":");
+                String shadowIp = shadowAddressInfos[0];
+                int shadowPort = Integer.parseInt(shadowAddressInfos[1]);
+                Reflection.setDeclaredValue("host", value, shadowIp);
+                Reflection.setDeclaredValue("port", value, shadowPort);
+            }
+        });
+    }
+
+    /**
+     * 从原始的pool 赋值到影子pool
+     * @param internalPool 原始的pool
+     * @param internalShadowPool 影子pool
+     */
+    private void copyPool(Object internalPool, Object internalShadowPool) {
+        Reflection.invokeDeclared("getMaxIdle", internalPool).ifPresent(value ->
+                Reflection.invokeDeclared("setMaxIdle", internalShadowPool, value));
+
+        Reflection.invokeDeclared("getMinIdle", internalPool).ifPresent(value ->
+                Reflection.invokeDeclared("setMinIdle", internalShadowPool, value));
+
+        Reflection.invokeDeclared("getMaxTotal", internalPool).ifPresent(value ->
+                Reflection.invokeDeclared("setMaxTotal", internalShadowPool, value));
+
+        Reflection.invokeDeclared("getMaxWaitMillis", internalPool).ifPresent(value ->
+                Reflection.invokeDeclared("setMaxWaitMillis", internalShadowPool, value));
+
+        Reflection.invokeDeclared("getBlockWhenExhausted", internalPool).ifPresent(value ->
+                Reflection.invokeDeclared("setBlockWhenExhausted", internalShadowPool, value));
+
+        Reflection.invokeDeclared("getFairness", internalPool).ifPresent(value ->
+                Reflection.invokeDeclared("setFairness", internalShadowPool, value));
+
+        Reflection.invokeDeclared("getLifo", internalPool).ifPresent(value ->
+                Reflection.invokeDeclared("setLifo", internalShadowPool, value));
+
+        Reflection.invokeDeclared("getTestOnBorrow", internalPool).ifPresent(value ->
+                Reflection.invokeDeclared("setTestOnBorrow", internalShadowPool, value));
+
+        Reflection.invokeDeclared("getTestOnCreate", internalPool).ifPresent(value ->
+                Reflection.invokeDeclared("setTestOnCreate", internalShadowPool, value));
+
+        Reflection.invokeDeclared("getTestOnReturn", internalPool).ifPresent(value ->
+                Reflection.invokeDeclared("setTestOnReturn", internalShadowPool, value));
+
+        Reflection.invokeDeclared("getTestWhileIdle", internalPool).ifPresent(value ->
+                Reflection.invokeDeclared("setTestWhileIdle", internalShadowPool, value));
+
+        Reflection.invokeDeclared("getNumTestsPerEvictionRun", internalPool).ifPresent(value ->
+                Reflection.invokeDeclared("setNumTestsPerEvictionRun", internalShadowPool, value));
+
+        Reflection.invokeDeclared("getMinEvictableIdleTimeMillis", internalPool).ifPresent(value ->
+                Reflection.invokeDeclared("setMinEvictableIdleTimeMillis", internalShadowPool, value));
+
+        Reflection.invokeDeclared("getTimeBetweenEvictionRunsMillis", internalPool).ifPresent(value ->
+                Reflection.invokeDeclared("setTimeBetweenEvictionRunsMillis", internalShadowPool, value));
+
+        Reflection.invokeDeclared("getSoftMinEvictableIdleTimeMillis", internalPool).ifPresent(value ->
+                Reflection.invokeDeclared("setSoftMinEvictableIdleTimeMillis", internalShadowPool, value));
+
+        Reflection.invokeDeclared("getEvictionPolicyClassName", internalPool).ifPresent(value ->
+                Reflection.invokeDeclared("setEvictionPolicyClassName", internalShadowPool, value));
+
+        Reflection.invokeDeclared("getEvictionPolicy", internalPool).ifPresent(value ->
+                Reflection.invokeDeclared("setEvictionPolicy", internalShadowPool, value));
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/Handler.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/Handler.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+
+package com.lubanops.stresstest.redis.jedis.command;
+
+import com.lubanops.stresstest.core.Tester;
+import com.lubanops.stresstest.redis.RedisUtils;
+
+/**
+ * 处理redis key
+ *
+ * @author yiwei
+ * @since 2021/11/1
+ */
+public interface Handler {
+    byte[][] handle(byte[][] bytes);
+
+    default byte[][] addShadowPrefix(int start, int end, int gap, byte[][] args) {
+        if (!Tester.isTest()) {
+            return args;
+        }
+        int length = args.length;
+        byte[][] results = new byte[args.length][];
+        if (length > 0) {
+            for (int i = start; i < end; i = i + gap) {
+                results[i] = RedisUtils.modifyBytes(args[i]);
+                if (gap - 1 > 0) {
+                    System.arraycopy(args, i + 1, results, i + 1, gap - 1);
+                }
+            }
+            for (int i = end; i < length; i = i + 1) {
+                System.arraycopy(args, i, results, i, length - end);
+            }
+        }
+        return results;
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/HandlerFactory.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/HandlerFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+package com.lubanops.stresstest.redis.jedis.command;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Redis handler Factory
+ *
+ * @author yiwei
+ * @since 2021/11/4
+ */
+public class HandlerFactory {
+    private static final Map<String, Handler> MAP = new HashMap<>();
+    private static final Handler DEFAULT_HANDLER = new NoopHandler();
+
+    static {
+        String[] noOpMethods = {"AUTH", "CLUSTER"};
+        for (String method : noOpMethods) {
+            MAP.put(method, DEFAULT_HANDLER);
+        }
+        String[] firstParamMethodNames = {"GET", "HGET", "HMGET", "HEXISTS", "SET", "SETNX", "SETEX", "EXPIRE",
+                "EXPIREAT", "TTL", "MOVE", "GETSET", "DECR", "DECRBY", "INCRBY", "INCR", "APPEND", "SUBSTR", "HSET",
+                "HSETNX", "HMSET", "HINCRBY", "HDEL", "HLEN", "HKEYS", "HVALS", "HGETALL", "RPUSH", "LPUSH", "LLEN",
+                "LRANGE", "LTRIM", "LINDEX", "LSET", "LREM", "LPOP", "RPOP", "SADD", "SMEMBERS", "SREM", "SPOP",
+                "SCARD", "SISMEMBER", "SRANDMEMBER", "ZADD", "ZRANGE", "ZREM", "ZRANK", "ZREVRANK", "ZREVRANGE",
+                "ZCARD", "ZSCORE", "ZCOUNT", "SORT", "ZRANGEBYSCORE", "ZREVRANGEBYSCORE", "ZREMRANGEBYRANK",
+                "ZREMRANGEBYSCORE", "ZUNIONSTORE", "ZINTERSTORE", "ZLEXCOUNT", "ZRANGEBYLEX", "ZREVRANGEBYLEX",
+                "ZREMRANGEBYLEX", "LPUSHX", "PERSIST", "RPUSHX", "LINSERT", "SETBIT", "GETBIT", "BITPOS", "SETRANGE",
+                "GETRANGE", "BITCOUNT", "DUMP", "RESTORE", "PEXPIRE", "PEXPIREAT", "PTTL", "INCRBYFLOAT", "PSETEX",
+                "HINCRBYFLOAT", "GEOADD", "GEODIST", "GEOHASH", "GEOPOS", "GEORADIUS", "GEORADIUSBYMEMBER", "BITFIELD"
+        };
+        Handler firstHandler = new ModifyFirstParamHandler();
+        for (String method : firstParamMethodNames) {
+            MAP.put(method, firstHandler);
+        }
+        String[] allParamsMethodNames = {  "DEL", "EXISTS", "TYPE", "RENAME", "RENAMENX", "RPOPLPUSH", "SINTER",
+                "SINTERSTORE", "SUNION", "SUNIONSTORE", "SDIFF", "SDIFFSTORE", "BLPOP", "BRPOP", "BITOP", "PFCOUNT",
+                "PFMERGE", "MGET"};
+        Handler allHandler = new ModifyAllParamsHandler();
+        for (String method : allParamsMethodNames) {
+            MAP.put(method, allHandler);
+        }
+        String[] skipValueMethodNames = {"MSET", "MSETNX"};
+        Handler skipValuesHandler = new ModifySkipValueHandler();
+        for (String method : skipValueMethodNames) {
+            MAP.put(method, skipValuesHandler);
+        }
+        String[] firstTwoMethodNames = {"SMOVE", "BRPOPLPUSH"};
+        Handler firstTwoHandler = new ModifyFirstTwoParamsHandler();
+        for (String method : firstTwoMethodNames) {
+            MAP.put(method, firstTwoHandler);
+        }
+    }
+
+    /**
+     * 获取命令对应的handler
+     *
+     * @param command 原始的redis command
+     * @return 去处理的handler
+     */
+    public static Handler getHandler(Object command) {
+        return MAP.getOrDefault(command.toString().toUpperCase(Locale.ROOT), DEFAULT_HANDLER);
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/ModifyAllParamsHandler.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/ModifyAllParamsHandler.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+package com.lubanops.stresstest.redis.jedis.command;
+
+/**
+ * 不做任何处理的handler。
+ *
+ * @author yiwei
+ * @since 2021/11/1
+ */
+public class ModifyAllParamsHandler implements Handler {
+    @Override
+    public byte[][] handle(byte[][] bytes) {
+        return addShadowPrefix(0, bytes.length, 1, bytes);
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/ModifyFirstParamHandler.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/ModifyFirstParamHandler.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+package com.lubanops.stresstest.redis.jedis.command;
+
+/**
+ * 不做任何处理的handler。
+ *
+ * @author yiwei
+ * @since 2021/11/1
+ */
+public class ModifyFirstParamHandler implements Handler {
+    @Override
+    public byte[][] handle(byte[][] bytes) {
+        return addShadowPrefix(0, 1, 1, bytes);
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/ModifyFirstTwoParamsHandler.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/ModifyFirstTwoParamsHandler.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+package com.lubanops.stresstest.redis.jedis.command;
+
+/**
+ * 不做任何处理的handler。
+ *
+ * @author yiwei
+ * @since 2021/11/1
+ */
+public class ModifyFirstTwoParamsHandler implements Handler {
+    @Override
+    public byte[][] handle(byte[][] bytes) {
+        return addShadowPrefix(0, 2, 1, bytes);
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/ModifySkipValueHandler.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/ModifySkipValueHandler.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+package com.lubanops.stresstest.redis.jedis.command;
+
+/**
+ * 不做任何处理的handler。
+ *
+ * @author yiwei
+ * @since 2021/11/1
+ */
+public class ModifySkipValueHandler implements Handler {
+    @Override
+    public byte[][] handle(byte[][] bytes) {
+        return addShadowPrefix(0, bytes.length, 2, bytes);
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/NoopHandler.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/NoopHandler.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+package com.lubanops.stresstest.redis.jedis.command;
+
+/**
+ * 不做任何处理的handler。
+ *
+ * @author yiwei
+ * @since 2021/11/1
+ */
+public class NoopHandler implements Handler {
+    @Override
+    public byte[][] handle(byte[][] bytes) {
+        return bytes;
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/lettuce/LettuceKeyEnhance.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/lettuce/LettuceKeyEnhance.java
@@ -1,26 +1,20 @@
-/*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
- */
-
-package com.lubanops.stresstest.kafka;
-
+package com.lubanops.stresstest.redis.lettuce;
 
 import com.huawei.apm.core.agent.definition.EnhanceDefinition;
 import com.huawei.apm.core.agent.definition.MethodInterceptPoint;
 import com.huawei.apm.core.agent.matcher.ClassMatcher;
 import com.huawei.apm.core.agent.matcher.ClassMatchers;
-
 import net.bytebuddy.matcher.ElementMatchers;
 
 /**
- * KafkaConsumer 增强
+ * Lettuce key 增强
  *
  * @author yiwei
- * @since 2021/10/26
+ * @since 2021/11/2
  */
-public class KafkaConsumerEnhance implements EnhanceDefinition {
-    private static final String ENHANCE_CLASS = "org.springframework.kafka.core.DefaultKafkaConsumerFactory";
-    private static final String INTERCEPT_CLASS = "com.lubanops.stresstest.kafka.KafkaConsumerInterceptor";
+public class LettuceKeyEnhance implements EnhanceDefinition {
+    private static final String ENHANCE_CLASS = "io.lettuce.core.protocol.CommandArgs";
+    private static final String INTERCEPT_CLASS = "com.lubanops.stresstest.redis.lettuce.LettuceKeyInterceptor";
 
     @Override
     public ClassMatcher enhanceClass() {
@@ -30,7 +24,7 @@ public class KafkaConsumerEnhance implements EnhanceDefinition {
     @Override
     public MethodInterceptPoint[] getMethodInterceptPoints() {
         return new MethodInterceptPoint[]{MethodInterceptPoint.newInstMethodInterceptPoint(INTERCEPT_CLASS,
-                ElementMatchers.named("createConsumer"))
+                ElementMatchers.namedOneOf("addKey", "addKeys"))
         };
     }
 }

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/lettuce/LettuceKeyInterceptor.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/lettuce/LettuceKeyInterceptor.java
@@ -1,31 +1,33 @@
 /*
  * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
  */
-package com.lubanops.stresstest.kafka;
+package com.lubanops.stresstest.redis.lettuce;
 
 import com.huawei.apm.core.agent.common.BeforeResult;
 import com.huawei.apm.core.agent.interceptor.InstanceMethodInterceptor;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
+import com.lubanops.stresstest.config.ConfigFactory;
+import com.lubanops.stresstest.core.Tester;
+import com.lubanops.stresstest.redis.RedisUtils;
 
 import java.lang.reflect.Method;
 
 /**
- * KafkaConsumer 增强实现
+ * Lettuce key 拦截器
  *
  * @author yiwei
- * @since 2021/10/27
+ * @since 2021/11/2
  */
-public class KafkaConsumerInterceptor implements InstanceMethodInterceptor {
+public class LettuceKeyInterceptor implements InstanceMethodInterceptor {
     @Override
     public void before(Object obj, Method method, Object[] arguments, BeforeResult beforeResult) {
+        if (Tester.isTest() && !ConfigFactory.getConfig().isRedisShadowRepositories() && arguments.length > 0) {
+            arguments[0] = RedisUtils.modifyKey(arguments[0]);
+        }
     }
 
     @Override
     public Object after(Object obj, Method method, Object[] arguments, Object result) {
-        if (result instanceof ShadowConsumer) {
-            return result;
-        }
-        return new ShadowConsumer<>((KafkaConsumer<?, ?>)result);
+        return result;
     }
 
     @Override

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/lettuce/LettucePoolEnhance.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/lettuce/LettucePoolEnhance.java
@@ -1,0 +1,38 @@
+package com.lubanops.stresstest.redis.lettuce;
+
+import com.huawei.apm.core.agent.definition.EnhanceDefinition;
+import com.huawei.apm.core.agent.definition.MethodInterceptPoint;
+import com.huawei.apm.core.agent.matcher.ClassMatcher;
+import com.huawei.apm.core.agent.matcher.ClassMatchers;
+import net.bytebuddy.matcher.ElementMatchers;
+
+/**
+ * Jedis pool增强
+ *
+ * @author yiwei
+ * @since 2021/11/3
+ */
+public class LettucePoolEnhance implements EnhanceDefinition {
+    /**
+     * ConnectionPoolSupport 方法 createGenericObjectPool
+     */
+    public static final String GENERIC_OBJECT_POOL_METHOD = "createGenericObjectPool";
+    /**
+     * ConnectionPoolSupport 方法 createSoftReferenceObjectPool
+     */
+    public static final String SOFT_OBJECT_POOL_METHOD = "createSoftReferenceObjectPool";
+    private static final String ENHANCE_CLASS = "io.lettuce.core.support.ConnectionPoolSupport";
+    private static final String INTERCEPT_CLASS = "com.lubanops.stresstest.redis.lettuce.LettucePoolInterceptor";
+
+    @Override
+    public ClassMatcher enhanceClass() {
+        return ClassMatchers.named(ENHANCE_CLASS);
+    }
+
+    @Override
+    public MethodInterceptPoint[] getMethodInterceptPoints() {
+        return new MethodInterceptPoint[]{MethodInterceptPoint.newStaticMethodInterceptPoint(INTERCEPT_CLASS,
+                ElementMatchers.namedOneOf(GENERIC_OBJECT_POOL_METHOD, SOFT_OBJECT_POOL_METHOD))
+        };
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/lettuce/LettucePoolInterceptor.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/lettuce/LettucePoolInterceptor.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+
+package com.lubanops.stresstest.redis.lettuce;
+
+import com.huawei.apm.core.agent.common.BeforeResult;
+import com.huawei.apm.core.agent.interceptor.StaticMethodInterceptor;
+import com.lubanops.stresstest.config.ConfigFactory;
+import com.lubanops.stresstest.redis.RedisUtils;
+import com.lubanops.stresstest.redis.lettuce.pool.GenericObjectPoolProxy;
+import com.lubanops.stresstest.redis.lettuce.pool.SoftObjectPoolProxy;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import org.apache.commons.pool2.BasePooledObjectFactory;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.apache.commons.pool2.impl.SoftReferenceObjectPool;
+
+import java.lang.reflect.Method;
+
+import static com.lubanops.stresstest.redis.lettuce.LettucePoolEnhance.GENERIC_OBJECT_POOL_METHOD;
+import static com.lubanops.stresstest.redis.lettuce.LettucePoolEnhance.SOFT_OBJECT_POOL_METHOD;
+
+/**
+ * Jedis pool 拦截器，返回影子redis 连接。
+ *
+ * @author yiwei
+ * @since 2021/10/21
+ */
+public class LettucePoolInterceptor implements StaticMethodInterceptor {
+    @Override
+    public void before(Class<?> clazz, Method method, Object[] arguments, BeforeResult beforeResult) {
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Object after(Class<?> clazz, Method method, Object[] arguments, Object result) {
+        if (ConfigFactory.getConfig().isRedisShadowRepositories()) {
+            String name = method.getName();
+            if (name.equals(GENERIC_OBJECT_POOL_METHOD)) {
+                if (result instanceof GenericObjectPoolProxy) {
+                    return result;
+                }
+                return newInstance((GenericObjectPoolConfig<StatefulRedisConnection<?, ?>>) arguments[1],
+                        (GenericObjectPool<StatefulRedisConnection<?, ?>>) result);
+            }
+            if (name.equals(SOFT_OBJECT_POOL_METHOD)) {
+                if (result instanceof SoftObjectPoolProxy) {
+                    return result;
+                }
+                return newInstance((SoftReferenceObjectPool<StatefulRedisConnection<?, ?>>) result);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void onThrow(Class<?> clazz, Method method, Object[] arguments, Throwable throwable) {
+    }
+
+    private GenericObjectPoolProxy<StatefulRedisConnection<?, ?>> newInstance(
+            GenericObjectPoolConfig<StatefulRedisConnection<?, ?>> config,
+            GenericObjectPool<StatefulRedisConnection<?, ?>> pool) {
+        RedisClient client = RedisClient.create(RedisUtils.getMasterAddress());
+        return new GenericObjectPoolProxy<>(new BasePooledObjectFactory<StatefulRedisConnection<?, ?>>() {
+            @Override
+            public StatefulRedisConnection<?, ?> create() {
+                return client.connect();
+            }
+
+            @Override
+            public PooledObject<StatefulRedisConnection<?, ?>> wrap(StatefulRedisConnection obj) {
+                return new DefaultPooledObject<StatefulRedisConnection<?, ?>>(obj);
+            }
+
+            @Override
+            public void destroyObject(PooledObject<StatefulRedisConnection<?, ?>> pooledObject) {
+                pooledObject.getObject().close();
+            }
+
+            @Override
+            public boolean validateObject(PooledObject<StatefulRedisConnection<?, ?>> pooledObject) {
+                return pooledObject.getObject().isOpen();
+            }
+        }, config, pool);
+    }
+
+    private SoftObjectPoolProxy<StatefulRedisConnection<?, ?>> newInstance(
+            SoftReferenceObjectPool<StatefulRedisConnection<?, ?>> pool) {
+        RedisClient client = RedisClient.create(RedisUtils.getMasterAddress());
+        return new SoftObjectPoolProxy<>(new BasePooledObjectFactory<StatefulRedisConnection<?, ?>>() {
+            @Override
+            public StatefulRedisConnection<?, ?> create() {
+                return client.connect();
+            }
+
+            @Override
+            public PooledObject<StatefulRedisConnection<?, ?>> wrap(StatefulRedisConnection obj) {
+                return new DefaultPooledObject<StatefulRedisConnection<?, ?>>(obj);
+            }
+
+            @Override
+            public void destroyObject(PooledObject<StatefulRedisConnection<?, ?>> pooledObject) {
+                pooledObject.getObject().close();
+            }
+
+            @Override
+            public boolean validateObject(PooledObject<StatefulRedisConnection<?, ?>> pooledObject) {
+                return pooledObject.getObject().isOpen();
+            }
+        }, pool);
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/lettuce/pool/GenericObjectPoolProxy.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/lettuce/pool/GenericObjectPoolProxy.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+package com.lubanops.stresstest.redis.lettuce.pool;
+
+import com.lubanops.stresstest.core.Tester;
+import org.apache.commons.pool2.PooledObjectFactory;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+
+/**
+ * GenericObjectPool proxy
+ * @param <T> type
+ * @author yiwei
+ * @since 2021/11/4
+ */
+public class GenericObjectPoolProxy<T> extends GenericObjectPool<T> {
+    private GenericObjectPool<T> originalPool;
+
+    public GenericObjectPoolProxy(PooledObjectFactory<T> factory, GenericObjectPoolConfig<T> config, GenericObjectPool<T> originalPool) {
+        super(factory, config);
+        this.originalPool = originalPool;
+    }
+
+    @Override
+    public T borrowObject() throws Exception {
+        if (Tester.isTest()) {
+            return super.borrowObject();
+        }
+        return originalPool.borrowObject();
+    }
+
+    @Override
+    public void returnObject(T obj) {
+        if (Tester.isTest()) {
+            super.returnObject(obj);
+        } else {
+            originalPool.returnObject(obj);
+        }
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/lettuce/pool/SoftObjectPoolProxy.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/lettuce/pool/SoftObjectPoolProxy.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+package com.lubanops.stresstest.redis.lettuce.pool;
+
+import com.lubanops.stresstest.core.Tester;
+import org.apache.commons.pool2.PooledObjectFactory;
+import org.apache.commons.pool2.impl.SoftReferenceObjectPool;
+
+/**
+ * SoftReferenceObjectPool proxy
+ *
+ * @param <T> type
+ * @author yiwei
+ * @since 2021/11/4
+ */
+public class SoftObjectPoolProxy<T> extends SoftReferenceObjectPool<T> {
+    private SoftReferenceObjectPool<T> originalPool;
+
+    public SoftObjectPoolProxy(PooledObjectFactory<T> factory, SoftReferenceObjectPool<T> originalPool) {
+        super(factory);
+        this.originalPool = originalPool;
+    }
+
+    @Override
+    public T borrowObject() throws Exception {
+        if (Tester.isTest()) {
+            return super.borrowObject();
+        }
+        return originalPool.borrowObject();
+    }
+
+    @Override
+    public void returnObject(T obj) throws Exception {
+        if (Tester.isTest()) {
+            super.returnObject(obj);
+        } else {
+            originalPool.returnObject(obj);
+        }
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/RedissonClusterEnhance.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/RedissonClusterEnhance.java
@@ -1,0 +1,31 @@
+package com.lubanops.stresstest.redis.redisson;
+
+import com.huawei.apm.core.agent.definition.EnhanceDefinition;
+import com.huawei.apm.core.agent.definition.MethodInterceptPoint;
+import com.huawei.apm.core.agent.matcher.ClassMatcher;
+import com.huawei.apm.core.agent.matcher.ClassMatchers;
+import net.bytebuddy.matcher.ElementMatchers;
+
+/**
+ * Redisson cluster 增强
+ *
+ * @author yiwei
+ * @since 2021/11/2
+ */
+public class RedissonClusterEnhance implements EnhanceDefinition {
+    private static final String CLUSTER_ENHANCE_CLASS = "org.redisson.cluster.ClusterConnectionManager";
+    private static final String MASTER_SLAVE_ENHANCE_CLASS = "org.redisson.connection.MasterSlaveConnectionManager";
+    private static final String INTERCEPT_CLASS = "com.lubanops.stresstest.redis.redisson.RedissonClusterInterceptor";
+
+    @Override
+    public ClassMatcher enhanceClass() {
+        return ClassMatchers.multiClass(CLUSTER_ENHANCE_CLASS, MASTER_SLAVE_ENHANCE_CLASS);
+    }
+
+    @Override
+    public MethodInterceptPoint[] getMethodInterceptPoints() {
+        return new MethodInterceptPoint[]{MethodInterceptPoint.newInstMethodInterceptPoint(INTERCEPT_CLASS,
+                ElementMatchers.named("calcSlot"))
+        };
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/RedissonClusterInterceptor.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/RedissonClusterInterceptor.java
@@ -1,31 +1,34 @@
 /*
  * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
  */
-package com.lubanops.stresstest.kafka;
+
+package com.lubanops.stresstest.redis.redisson;
 
 import com.huawei.apm.core.agent.common.BeforeResult;
 import com.huawei.apm.core.agent.interceptor.InstanceMethodInterceptor;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
+import com.lubanops.stresstest.config.ConfigFactory;
+import com.lubanops.stresstest.core.Tester;
+import com.lubanops.stresstest.redis.RedisUtils;
 
 import java.lang.reflect.Method;
 
 /**
- * KafkaConsumer 增强实现
+ * Redisson Cluster 拦截器，修改getSlot方法。
  *
  * @author yiwei
- * @since 2021/10/27
+ * @since 2021/10/21
  */
-public class KafkaConsumerInterceptor implements InstanceMethodInterceptor {
+public class RedissonClusterInterceptor implements InstanceMethodInterceptor {
     @Override
     public void before(Object obj, Method method, Object[] arguments, BeforeResult beforeResult) {
+        if (Tester.isTest() && !ConfigFactory.getConfig().isRedisShadowRepositories() && arguments.length > 0 ) {
+            arguments[0] = RedisUtils.modifySingleKey(arguments[0]);
+        }
     }
 
     @Override
     public Object after(Object obj, Method method, Object[] arguments, Object result) {
-        if (result instanceof ShadowConsumer) {
-            return result;
-        }
-        return new ShadowConsumer<>((KafkaConsumer<?, ?>)result);
+        return result;
     }
 
     @Override

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/RedissonKeyEnhance.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/RedissonKeyEnhance.java
@@ -1,0 +1,31 @@
+package com.lubanops.stresstest.redis.redisson;
+
+import com.huawei.apm.core.agent.definition.EnhanceDefinition;
+import com.huawei.apm.core.agent.definition.MethodInterceptPoint;
+import com.huawei.apm.core.agent.matcher.ClassMatcher;
+import com.huawei.apm.core.agent.matcher.ClassMatchers;
+import net.bytebuddy.matcher.ElementMatchers;
+
+/**
+ * Redisson key 增强
+ *
+ * @author yiwei
+ * @since 2021/11/2
+ */
+public class RedissonKeyEnhance implements EnhanceDefinition {
+    private static final String ENHANCE_ASYNC_CLASS = "org.redisson.command.CommandAsyncService";
+    private static final String ENHANCE_BATCH_CLASS = "org.redisson.command.CommandBatchService";
+    private static final String INTERCEPT_CLASS = "com.lubanops.stresstest.redis.redisson.RedissonKeyInterceptor";
+
+    @Override
+    public ClassMatcher enhanceClass() {
+        return ClassMatchers.multiClass(ENHANCE_ASYNC_CLASS, ENHANCE_BATCH_CLASS);
+    }
+
+    @Override
+    public MethodInterceptPoint[] getMethodInterceptPoints() {
+        return new MethodInterceptPoint[]{MethodInterceptPoint.newInstMethodInterceptPoint(INTERCEPT_CLASS,
+                ElementMatchers.named("async"))
+        };
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/RedissonKeyInterceptor.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/RedissonKeyInterceptor.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+package com.lubanops.stresstest.redis.redisson;
+
+import com.huawei.apm.core.agent.common.BeforeResult;
+import com.huawei.apm.core.agent.interceptor.InstanceMethodInterceptor;
+import com.lubanops.stresstest.config.ConfigFactory;
+import com.lubanops.stresstest.core.Reflection;
+import com.lubanops.stresstest.core.Tester;
+
+import java.lang.reflect.Method;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Redisson key 拦截器
+ *
+ * @author yiwei
+ * @since 2021/11/2
+ */
+public class RedissonKeyInterceptor implements InstanceMethodInterceptor {
+    private static final int COMMAND_LOCATION = 3;
+    private static final String EVAL_COMMAND = "EVAL";
+    private static final Pattern PATTERN = Pattern.compile("\\{(.+?)}");
+    private static final String KEY = ConfigFactory.getConfig().getTestRedisPrefix();
+
+    @Override
+    public void before(Object obj, Method method, Object[] arguments, BeforeResult beforeResult) {
+        if (Tester.isTest() && !ConfigFactory.getConfig().isRedisShadowRepositories() && arguments.length > COMMAND_LOCATION + 1) {
+            modifyRedissonCommand(arguments[COMMAND_LOCATION], (Object[])arguments[COMMAND_LOCATION + 1]);
+        }
+    }
+
+    @Override
+    public Object after(Object obj, Method method, Object[] arguments, Object result) {
+        return result;
+    }
+
+    @Override
+    public void onThrow(Object obj, Method method, Object[] arguments, Throwable throwable) {
+    }
+
+    private void modifyRedissonCommand(Object command, Object[] params) {
+        Reflection.getDeclaredValue("name", command).ifPresent(name -> {
+            // EVAL 命令，第一个参数是带参数的命令行，第二个参数是参数个数，后面是所有的参数
+            if (name.toString().equalsIgnoreCase(EVAL_COMMAND)) {
+                if (params.length < 3) {
+                    return;
+                }
+                if (params[1] instanceof Integer) {
+                    for (int i = 0; i < (Integer)params[1]; i++) {
+                        modifyKey(params, i + 2);
+                    }
+                }
+                return;
+            }
+            for (int i = 0; i < params.length; i++) {
+                if (!modifyKey(params, i)) {
+                    break;
+                }
+            }
+        });
+    }
+
+    private boolean modifyMainKey(Object[] params, int index) {
+        String content = (String) params[index];
+        Matcher matcher = PATTERN.matcher(content);
+        if (matcher.find()) {
+            String original = matcher.group(1);
+            if (!original.startsWith(KEY)) {
+                params[index] = content.replaceAll(original, KEY + original);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean modifyKey(Object[] params, int index) {
+        if (!(params[index] instanceof String)) {
+            return false;
+        }
+        if (modifyMainKey(params, index)) {
+            return true;
+        }
+        String content = (String) params[index];
+        if (!content.startsWith(KEY)) {
+            params[index] = KEY + params[index];
+            return true;
+        }
+        return false;
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/RedissonObjectEnhance.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/RedissonObjectEnhance.java
@@ -1,0 +1,30 @@
+package com.lubanops.stresstest.redis.redisson;
+
+import com.huawei.apm.core.agent.definition.EnhanceDefinition;
+import com.huawei.apm.core.agent.definition.MethodInterceptPoint;
+import com.huawei.apm.core.agent.matcher.ClassMatcher;
+import com.huawei.apm.core.agent.matcher.ClassMatchers;
+import net.bytebuddy.matcher.ElementMatchers;
+
+/**
+ * Redisson Object 增强
+ *
+ * @author yiwei
+ * @since 2021/11/3
+ */
+public class RedissonObjectEnhance implements EnhanceDefinition {
+    private static final String ENHANCE_CLASS = "org.redisson.command.RedisExecutor";
+    private static final String INTERCEPT_CLASS = "com.lubanops.stresstest.redis.redisson.RedissonObjectInterceptor";
+
+    @Override
+    public ClassMatcher enhanceClass() {
+        return ClassMatchers.named(ENHANCE_CLASS);
+    }
+
+    @Override
+    public MethodInterceptPoint[] getMethodInterceptPoints() {
+        return new MethodInterceptPoint[]{MethodInterceptPoint.newConstructorInterceptPoint(INTERCEPT_CLASS,
+                ElementMatchers.any())
+        };
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/RedissonObjectInterceptor.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/RedissonObjectInterceptor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+package com.lubanops.stresstest.redis.redisson;
+
+
+import com.huawei.apm.core.agent.interceptor.ConstructorInterceptor;
+import com.lubanops.stresstest.config.ConfigFactory;
+import com.lubanops.stresstest.core.Reflection;
+import com.lubanops.stresstest.core.Tester;
+
+
+import static com.lubanops.stresstest.redis.redisson.RedissonUtils.getSetShadowConnectionManager;
+
+/**
+ * Redisson Object 拦截器, redisson 分库
+ *
+ * @author yiwei
+ * @since 2021/11/2
+ */
+public class RedissonObjectInterceptor implements ConstructorInterceptor {
+    private static final String CONNECTION_MANAGER = "connectionManager";
+
+    @Override
+    public void onConstruct(Object obj, Object[] allArguments) {
+        if (Tester.isTest() && ConfigFactory.getConfig().isRedisShadowRepositories()) {
+            Reflection.getDeclaredValue(CONNECTION_MANAGER, obj).ifPresent(connectionManager -> Reflection.setDeclaredValue(
+                    CONNECTION_MANAGER, obj, getSetShadowConnectionManager(connectionManager), true));
+        }
+    }
+
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/RedissonUtils.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/RedissonUtils.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+package com.lubanops.stresstest.redis.redisson;
+
+import com.huawei.apm.core.lubanops.bootstrap.log.LogFactory;
+import com.lubanops.stresstest.config.ConfigFactory;
+import com.lubanops.stresstest.core.Reflection;
+import com.lubanops.stresstest.redis.redisson.config.ShadowConfigChains;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Optional;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.logging.Logger;
+
+/**
+ * redisson 影子相关的工具库
+ *
+ * @author yiwei
+ * @since 2021/11/4
+ */
+public class RedissonUtils {
+    private static final Logger LOGGER = LogFactory.getLogger();
+    private static final String CONNECTION_MANAGER = "org.redisson.connection.ConnectionManager";
+    private static final String ASYNC_EXECUTOR = "org.redisson.command.CommandAsyncExecutor";
+    private static final String REDISSON_CLIENT = "org.redisson.api.RedissonClient";
+    private static final String REDISSON_MAP_CACHE = "org.redisson.RedissonMapCache";
+
+    private static final int OLD_REDISSON_COUNT = 2;
+
+    private static final int NEW_REDISSON_COUNT = 3;
+
+    private static final int NEW_REDISSON_MAP_COUNT = 5;
+
+    private static final int REDISSON_LOC = 2;
+    private static ReentrantLock lock = new ReentrantLock();
+    private static volatile Object connectionManager;
+
+    /**
+     * 根据原始的redisson object，修改key创建对应的redisson object
+     * @param object 原始的object
+     * @return 影子redisson object
+     */
+    public static Optional<Object> buildShadowObject(Object object) {
+        return Reflection.invokeDeclared("getName", object).map(name -> {
+            if (name.toString().startsWith(ConfigFactory.getConfig().getTestRedisPrefix())) {
+                return null;
+            }
+            String shadowName;
+            if (!ConfigFactory.getConfig().isRedisShadowRepositories()) {
+                shadowName = ConfigFactory.getConfig().getTestRedisPrefix() + name;
+            } else {
+                shadowName = name.toString();
+            }
+            return Reflection.getDeclaredValue("commandExecutor", object).map(executor -> {
+                Constructor<?>[] constructors = executor.getClass().getDeclaredConstructors();
+                for (Constructor<?> constructor : constructors) {
+                    Class<?>[] types = constructor.getParameterTypes();
+                    if (types.length == 1 && types[0].getName().equals(CONNECTION_MANAGER)) {
+                        Reflection.accessible(constructor);
+                        return Reflection.getDeclaredValue("connectionManager",
+                                executor).map(connectionManager -> {
+                                    Optional<Boolean> shadowObj = Reflection.invokeDeclared("getCfg", connectionManager).map(ShadowConfigChains::isShadowObject);
+                                    if (shadowObj.isPresent() && shadowObj.get()) {
+                                        return null;
+                                    }
+                                    try {
+                                        Object commandExecutor = constructor.newInstance(getSetShadowConnectionManager(connectionManager));
+                                        return newShadowNewObject(object, commandExecutor, shadowName,
+                                                getClientFromCommandExecutor(executor)).orElseGet(
+                                                () -> newShadowOldObject(object, commandExecutor, shadowName).orElse(null));
+                                    } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+                                        LOGGER.info(String.format("Cannot build constructor, %s.", executor.getClass().getName()));
+                                    }
+                                    return null;
+                                }).orElse(null);
+                    }
+                }
+                return null;
+            }).orElse(null);
+        });
+    }
+
+    private static Optional<Object> newShadowNewObject(Object object, Object commandExecutor, String name,
+                Object redisson) {
+        Class<?> clazz = object.getClass();
+        if (clazz.getName().equals(REDISSON_MAP_CACHE)) {
+            return newShadowMapCache(object, clazz, commandExecutor, name, redisson);
+        } else {
+            try {
+                Constructor<?>[] constructors = clazz.getDeclaredConstructors();
+                for (Constructor<?> constructor : constructors) {
+                    Class<?>[] types = constructor.getParameterTypes();
+                    if (types.length >= NEW_REDISSON_COUNT && isExecutor(types[0]) && types[1] == String.class
+                            && types[REDISSON_LOC].getName().equals(REDISSON_CLIENT)) {
+                        Reflection.accessible(constructor);
+                        Object result;
+                        if (types.length == NEW_REDISSON_COUNT) {
+                            result = constructor.newInstance(commandExecutor, name, redisson);
+                        } else if (types.length == NEW_REDISSON_MAP_COUNT) {
+                            result = constructor.newInstance(commandExecutor, name, redisson, null, null);
+                        } else {
+                            continue;
+                        }
+                        return Optional.of(result);
+                    }
+                }
+            } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {
+                LOGGER.info(String.format("Cannot build constructor %s.", clazz.getName()));
+            }
+            return Optional.empty();
+        }
+    }
+
+    private static Optional<Object> newShadowOldObject(Object object, Object commandExecutor, String name) {
+        Class<?> clazz = object.getClass();
+        try {
+            Constructor<?>[] constructors = clazz.getDeclaredConstructors();
+            for (Constructor<?> constructor : constructors) {
+                Class<?>[] types = constructor.getParameterTypes();
+                if (types.length == OLD_REDISSON_COUNT && isExecutor(types[0])
+                        && types[1] == String.class) {
+                    Reflection.accessible(constructor);
+                    Object result = constructor.newInstance(commandExecutor, name);
+                    return Optional.of(result);
+                }
+            }
+        } catch (IllegalAccessException | InstantiationException | InvocationTargetException e) {
+            LOGGER.info(String.format("Cannot build constructor %s.", clazz.getName()));
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<Object> newShadowMapCache(
+            Object original, Class<?> clazz, Object commandExecutor, String name, Object redisson) {
+        Constructor<?>[] constructors = clazz.getDeclaredConstructors();
+        for (Constructor<?> constructor : constructors) {
+            Class<?>[] types = constructor.getParameterTypes();
+            if (types.length == 6 && isExecutor(types[1]) && types[2] == String.class && types[3].getName()
+                    .equals(REDISSON_CLIENT)) {
+                Reflection.accessible(constructor);
+                return Reflection.getDeclaredValue("evictionScheduler", original).map(evictionScheduler -> {
+                    Object result = null;
+                    try {
+                        result = constructor.newInstance(evictionScheduler, commandExecutor, name, redisson,
+                                null, null);
+                    } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+                        LOGGER.info(String.format("Cannot build constructor %s.", clazz.getName()));
+                    }
+                    return result;
+                });
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static boolean isExecutor(Class<?> clazz) {
+        if (clazz.getName().equals(ASYNC_EXECUTOR)) {
+            return true;
+        } else {
+            Class<?>[] subClasses = clazz.getInterfaces();
+            for (Class<?> subClazz:subClasses) {
+                if (isExecutor(subClazz)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * 从commandexecutor中获取redisson client
+     * @param commandExecutor commandexecutor
+     * @return redisson client
+     */
+    private static Object getClientFromCommandExecutor(Object commandExecutor) {
+        return Reflection.getDeclaredValue("redisson", commandExecutor).orElseGet(
+                () -> Reflection.getDeclaredValue("objectBuilder", commandExecutor).flatMap(builder ->
+                        Reflection.getDeclaredValue("redisson", builder)).orElse(null));
+    }
+
+    /**
+     * 获取影子的connectionManager
+     *
+     * @param localConnectionManager 原始的connectionManager
+     * @return 影子的connectionManger
+     */
+    public static Object getSetShadowConnectionManager(Object localConnectionManager) {
+        if (!ConfigFactory.getConfig().isRedisShadowRepositories()) {
+            return localConnectionManager;
+        }
+        if (connectionManager == null) {
+            lock.lock();
+            try {
+                if (connectionManager == null) {
+                    Reflection.invokeDeclared("getCfg", localConnectionManager)
+                            .flatMap(RedissonUtils::createConnectionManager)
+                            .ifPresent(shadowManager -> connectionManager = shadowManager);
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
+        if (connectionManager != null) {
+            return connectionManager;
+        } else {
+            LOGGER.warning("Use original redisson client");
+            return localConnectionManager;
+        }
+    }
+
+    static Optional<Object> createConnectionManager(Object config) {
+        return shadowConfig(config).map(shadowConfig -> Reflection.invokeStaticDeclared("createConnectionManager",
+                "org.redisson.config.ConfigSupport", shadowConfig).orElse(config));
+    }
+
+    /**
+     * 创建redisson影子config
+     *
+     * @param config 原始的config
+     * @return 影子config
+     */
+    static Optional<Object> shadowConfig(Object config) {
+        Class<?> clazz = config.getClass();
+        try {
+            Constructor<?> constructor = clazz.getConstructor(clazz);
+            Object shadowConfig = constructor.newInstance(config);
+            ShadowConfigChains.update(shadowConfig);
+            return Optional.of(shadowConfig);
+        } catch (NoSuchMethodException | IllegalAccessException | InstantiationException
+                | InvocationTargetException e) {
+            LOGGER.severe("Cannot new shadow config.");
+        }
+        return Optional.empty();
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowClusterConfig.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowClusterConfig.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+package com.lubanops.stresstest.redis.redisson.config;
+
+import com.lubanops.stresstest.redis.RedisUtils;
+
+/**
+ * 生产影子 single config
+ *
+ * @author yiwei
+ * @since 2021/11/4
+ */
+public class ShadowClusterConfig extends ShadowConfig{
+    public ShadowClusterConfig() {
+        super("clusterServersConfig", NODE_ADDRESS);
+    }
+
+    @Override
+    protected Object getAddress() {
+        return RedisUtils.getNodeAddress();
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowConfig.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowConfig.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+package com.lubanops.stresstest.redis.redisson.config;
+
+import com.lubanops.stresstest.core.Reflection;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * 生产影子config的基类
+ *
+ * @author yiwei
+ * @since 2021/11/4
+ */
+public abstract class ShadowConfig {
+    static final String ADDRESS = "address";
+    static final String NODE_ADDRESS = "nodeAddresses";
+    private String serverConfig;
+    private String field;
+
+    public ShadowConfig(String serverConfig, String field) {
+        this.serverConfig = serverConfig;
+        this.field = field;
+    }
+
+    /**
+     * 获取要配置的地址信息
+     *
+     * @return 影子配置信息
+     */
+    protected abstract Object getAddress();
+
+    /**
+     * 更新影子配置的地址信息
+     *
+     * @param shadowObject 影子配置
+     */
+    protected Optional<Object> update(Object shadowObject){
+        return Reflection.getDeclaredValue(serverConfig, shadowObject).map(configValue -> {
+            Reflection.setDeclaredValue(field, configValue, getAddress());
+            return configValue;
+        });
+    }
+
+    /**
+     * 检查当前配置是否为影子配置
+     *
+     * @param shadowObject 待检查配置
+     * @return 影子配置返回true，否则返回false
+     */
+    protected boolean isShadowObject(Object shadowObject) {
+        AtomicBoolean value = new AtomicBoolean(false);
+        Reflection.getDeclaredValue(serverConfig, shadowObject).flatMap(configValue -> Reflection.getDeclaredValue(field, configValue)).ifPresent(address -> {
+            if (address.equals(getAddress())) {
+                value.set(true);
+            }
+        });
+        return value.get();
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowConfigChains.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowConfigChains.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+package com.lubanops.stresstest.redis.redisson.config;
+
+/**
+ * 影子配置责任链
+ *
+ * @author yiwei
+ * @since 2021/11/4
+ */
+public class ShadowConfigChains {
+    private static final ShadowConfig[] CONFIGS = {new ShadowClusterConfig(),
+    new ShadowSentinelConfig(), new ShadowMasterSlaveConfig(), new ShadowReplicatedConfig(), new ShadowSingleConfig()};
+
+    /**
+     * 更新影子配置的地址信息
+     *
+     * @param shadowObject 影子配置
+     */
+    public static void update(Object shadowObject) {
+        for (ShadowConfig config: CONFIGS) {
+            if (config.update(shadowObject).isPresent()) {
+                return;
+            }
+        }
+    }
+
+    /**
+     * 检查当前配置是否为影子配置
+     *
+     * @param shadowObject 待检查配置
+     * @return 影子配置返回true，否则返回false
+     */
+    public static boolean isShadowObject(Object shadowObject) {
+        for (ShadowConfig config: CONFIGS) {
+            if (config.isShadowObject(shadowObject)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowMasterSlaveConfig.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowMasterSlaveConfig.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+package com.lubanops.stresstest.redis.redisson.config;
+
+import com.lubanops.stresstest.core.Reflection;
+import com.lubanops.stresstest.redis.RedisUtils;
+
+import java.util.Optional;
+
+/**
+ * 生产影子 single config
+ *
+ * @author yiwei
+ * @since 2021/11/4
+ */
+public class ShadowMasterSlaveConfig extends ShadowConfig{
+    public ShadowMasterSlaveConfig() {
+        super("masterSlaveServersConfig", "masterAddress");
+    }
+
+    @Override
+    protected Object getAddress() {
+        return RedisUtils.getMasterAddress();
+    }
+
+    @Override
+    protected Optional<Object> update(Object shadowObject) {
+        return super.update(shadowObject).map(configValue -> {
+            Reflection.setDeclaredValue("slaveAddresses", configValue, RedisUtils.getSalveRedisAddress());
+            return configValue;
+        });
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowReplicatedConfig.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowReplicatedConfig.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+package com.lubanops.stresstest.redis.redisson.config;
+
+import com.lubanops.stresstest.redis.RedisUtils;
+
+/**
+ * 生产影子 single config
+ *
+ * @author yiwei
+ * @since 2021/11/4
+ */
+public class ShadowReplicatedConfig extends ShadowConfig{
+    public ShadowReplicatedConfig() {
+        super("replicatedServersConfig", NODE_ADDRESS);
+    }
+
+    @Override
+    protected Object getAddress() {
+        return RedisUtils.getNodeAddress();
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowSentinelConfig.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowSentinelConfig.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+package com.lubanops.stresstest.redis.redisson.config;
+
+import com.lubanops.stresstest.redis.RedisUtils;
+
+/**
+ * 生产影子 single config
+ *
+ * @author yiwei
+ * @since 2021/11/4
+ */
+public class ShadowSentinelConfig extends ShadowConfig{
+    public ShadowSentinelConfig() {
+        super("sentinelServersConfig", "sentinelAddresses");
+    }
+
+    @Override
+    protected Object getAddress() {
+        return RedisUtils.getNodeAddress();
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowSingleConfig.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowSingleConfig.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+package com.lubanops.stresstest.redis.redisson.config;
+
+import com.lubanops.stresstest.redis.RedisUtils;
+
+/**
+ * 生产影子 single config
+ *
+ * @author yiwei
+ * @since 2021/11/4
+ */
+public class ShadowSingleConfig extends ShadowConfig{
+    public ShadowSingleConfig() {
+        super("singleServerConfig", ADDRESS);
+    }
+
+    @Override
+    protected Object getAddress() {
+        return RedisUtils.getMasterAddress();
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/workaround/RedissonLimiterDeleteEnhance.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/workaround/RedissonLimiterDeleteEnhance.java
@@ -1,36 +1,29 @@
-/*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
- */
-
-package com.lubanops.stresstest.kafka;
-
+package com.lubanops.stresstest.redis.redisson.workaround;
 
 import com.huawei.apm.core.agent.definition.EnhanceDefinition;
 import com.huawei.apm.core.agent.definition.MethodInterceptPoint;
 import com.huawei.apm.core.agent.matcher.ClassMatcher;
 import com.huawei.apm.core.agent.matcher.ClassMatchers;
-
 import net.bytebuddy.matcher.ElementMatchers;
 
 /**
- * KafkaConsumer 增强
+ * Redisson Limiter 增强
  *
  * @author yiwei
- * @since 2021/10/26
+ * @since 2021/11/3
  */
-public class KafkaConsumerEnhance implements EnhanceDefinition {
-    private static final String ENHANCE_CLASS = "org.springframework.kafka.core.DefaultKafkaConsumerFactory";
-    private static final String INTERCEPT_CLASS = "com.lubanops.stresstest.kafka.KafkaConsumerInterceptor";
+public class RedissonLimiterDeleteEnhance implements EnhanceDefinition {
+    private static final String INTERCEPT_CLASS = "com.lubanops.stresstest.redis.redisson.workaround.RedissonLimiterDeleteInterceptor";
 
     @Override
     public ClassMatcher enhanceClass() {
-        return ClassMatchers.named(ENHANCE_CLASS);
+        return ClassMatchers.named("org.redisson.RedissonObject");
     }
 
     @Override
     public MethodInterceptPoint[] getMethodInterceptPoints() {
         return new MethodInterceptPoint[]{MethodInterceptPoint.newInstMethodInterceptPoint(INTERCEPT_CLASS,
-                ElementMatchers.named("createConsumer"))
+                ElementMatchers.named("delete"))
         };
     }
 }

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/workaround/RedissonLimiterDeleteInterceptor.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/workaround/RedissonLimiterDeleteInterceptor.java
@@ -1,34 +1,37 @@
 /*
  * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
  */
-package com.lubanops.stresstest.kafka;
+package com.lubanops.stresstest.redis.redisson.workaround;
+
 
 import com.huawei.apm.core.agent.common.BeforeResult;
 import com.huawei.apm.core.agent.interceptor.InstanceMethodInterceptor;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
 
 import java.lang.reflect.Method;
 
+import static com.lubanops.stresstest.redis.redisson.workaround.RedissonShadowInterceptor.invokeOnShadow;
+
 /**
- * KafkaConsumer 增强实现
+ * 影子RedissonLimiter 拦截器
  *
  * @author yiwei
- * @since 2021/10/27
+ * @since 2021/11/4
  */
-public class KafkaConsumerInterceptor implements InstanceMethodInterceptor {
+public class RedissonLimiterDeleteInterceptor implements InstanceMethodInterceptor {
     @Override
     public void before(Object obj, Method method, Object[] arguments, BeforeResult beforeResult) {
     }
 
     @Override
     public Object after(Object obj, Method method, Object[] arguments, Object result) {
-        if (result instanceof ShadowConsumer) {
-            return result;
+        if (obj.getClass().getName().equals("org.redisson.RedissonRateLimiter")) {
+            return invokeOnShadow(obj, method, arguments, result);
         }
-        return new ShadowConsumer<>((KafkaConsumer<?, ?>)result);
+        return result;
     }
 
     @Override
     public void onThrow(Object obj, Method method, Object[] arguments, Throwable throwable) {
     }
 }
+

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/workaround/RedissonLimiterEnhance.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/workaround/RedissonLimiterEnhance.java
@@ -1,36 +1,29 @@
-/*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
- */
-
-package com.lubanops.stresstest.kafka;
-
+package com.lubanops.stresstest.redis.redisson.workaround;
 
 import com.huawei.apm.core.agent.definition.EnhanceDefinition;
 import com.huawei.apm.core.agent.definition.MethodInterceptPoint;
 import com.huawei.apm.core.agent.matcher.ClassMatcher;
 import com.huawei.apm.core.agent.matcher.ClassMatchers;
-
 import net.bytebuddy.matcher.ElementMatchers;
 
 /**
- * KafkaConsumer 增强
+ * Redisson Limiter 增强
  *
  * @author yiwei
- * @since 2021/10/26
+ * @since 2021/11/3
  */
-public class KafkaConsumerEnhance implements EnhanceDefinition {
-    private static final String ENHANCE_CLASS = "org.springframework.kafka.core.DefaultKafkaConsumerFactory";
-    private static final String INTERCEPT_CLASS = "com.lubanops.stresstest.kafka.KafkaConsumerInterceptor";
+public class RedissonLimiterEnhance implements EnhanceDefinition {
+    private static final String INTERCEPT_CLASS = "com.lubanops.stresstest.redis.redisson.workaround.RedissonShadowInterceptor";
 
     @Override
     public ClassMatcher enhanceClass() {
-        return ClassMatchers.named(ENHANCE_CLASS);
+        return ClassMatchers.named("org.redisson.RedissonRateLimiter");
     }
 
     @Override
     public MethodInterceptPoint[] getMethodInterceptPoints() {
         return new MethodInterceptPoint[]{MethodInterceptPoint.newInstMethodInterceptPoint(INTERCEPT_CLASS,
-                ElementMatchers.named("createConsumer"))
+                ElementMatchers.named("trySetRate"))
         };
     }
 }

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/workaround/RedissonQueueEnhance.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/workaround/RedissonQueueEnhance.java
@@ -1,36 +1,30 @@
-/*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
- */
-
-package com.lubanops.stresstest.kafka;
-
+package com.lubanops.stresstest.redis.redisson.workaround;
 
 import com.huawei.apm.core.agent.definition.EnhanceDefinition;
 import com.huawei.apm.core.agent.definition.MethodInterceptPoint;
 import com.huawei.apm.core.agent.matcher.ClassMatcher;
 import com.huawei.apm.core.agent.matcher.ClassMatchers;
-
 import net.bytebuddy.matcher.ElementMatchers;
 
 /**
- * KafkaConsumer 增强
+ * Redisson Queue 增强
  *
  * @author yiwei
- * @since 2021/10/26
+ * @since 2021/11/3
  */
-public class KafkaConsumerEnhance implements EnhanceDefinition {
-    private static final String ENHANCE_CLASS = "org.springframework.kafka.core.DefaultKafkaConsumerFactory";
-    private static final String INTERCEPT_CLASS = "com.lubanops.stresstest.kafka.KafkaConsumerInterceptor";
+public class RedissonQueueEnhance implements EnhanceDefinition {
+    private static final String INTERCEPT_CLASS = "com.lubanops.stresstest.redis.redisson.workaround.RedissonShadowInterceptor";
 
     @Override
     public ClassMatcher enhanceClass() {
-        return ClassMatchers.named(ENHANCE_CLASS);
+        return ClassMatchers.multiClass("org.redisson.RedissonBoundedBlockingQueue",
+                "org.redisson.RedissonBlockingQueue", "org.redisson.RedissonBlockingDeque");
     }
 
     @Override
     public MethodInterceptPoint[] getMethodInterceptPoints() {
         return new MethodInterceptPoint[]{MethodInterceptPoint.newInstMethodInterceptPoint(INTERCEPT_CLASS,
-                ElementMatchers.named("createConsumer"))
+                ElementMatchers.named("trySetCapacity"))
         };
     }
 }

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/workaround/RedissonShadowInterceptor.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/workaround/RedissonShadowInterceptor.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ */
+package com.lubanops.stresstest.redis.redisson.workaround;
+
+import com.huawei.apm.core.agent.common.BeforeResult;
+import com.huawei.apm.core.agent.interceptor.InstanceMethodInterceptor;
+import com.huawei.apm.core.lubanops.bootstrap.log.LogFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.logging.Logger;
+
+import static com.lubanops.stresstest.redis.redisson.RedissonUtils.buildShadowObject;
+
+/**
+ * Redisson Queue 拦截器
+ *
+ * @author yiwei
+ * @since 2021/11/3
+ */
+public class RedissonShadowInterceptor implements InstanceMethodInterceptor {
+    private static final Logger LOGGER = LogFactory.getLogger();
+
+    @Override
+    public void before(Object obj, Method method, Object[] arguments, BeforeResult beforeResult) {
+    }
+
+    @Override
+    public Object after(Object obj, Method method, Object[] arguments, Object result) {
+        return invokeOnShadow(obj, method, arguments, result);
+    }
+
+    @Override
+    public void onThrow(Object obj, Method method, Object[] arguments, Throwable throwable) {
+    }
+
+    /**
+     * 在影子对象上调用方法
+     *
+     * @param obj 原始的对象
+     * @param method 待执行的方法
+     * @param arguments 方法的参数
+     * @param result 返回值
+     * @return 原始的返回值。
+     */
+    public static Object invokeOnShadow(Object obj, Method method, Object[] arguments, Object result) {
+        buildShadowObject(obj).ifPresent(shadowInstance -> {
+            try {
+                method.invoke(shadowInstance, arguments);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                LOGGER.severe(String.format("Cannot execute method %s for reason %s.", method.getName(),
+                        e.getMessage()));
+            }
+        });
+        return result;
+    }
+}

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/servlet/WebRequestInterceptor.java
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/servlet/WebRequestInterceptor.java
@@ -12,7 +12,7 @@ import com.lubanops.stresstest.core.Tester;
 import javax.servlet.http.HttpServletRequest;
 import java.lang.reflect.Method;
 
-import static com.lubanops.stresstest.core.Tester.TEST_FLAG;
+import static com.lubanops.stresstest.config.Constant.TEST_FLAG;
 
 /**
  * HTTP 拦截器，当请求头中包含压测字段时，给线程打上压测标记。

--- a/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/resources/META-INF/services/com.huawei.apm.core.agent.definition.EnhanceDefinition
+++ b/javamesh-samples/javamesh-online-stresstest/online-stresstest-plugin/src/main/resources/META-INF/services/com.huawei.apm.core.agent.definition.EnhanceDefinition
@@ -4,3 +4,16 @@ com.lubanops.stresstest.http.HttpClientEnhance
 com.lubanops.stresstest.http.AsyncHttpClientEnhance
 com.lubanops.stresstest.kafka.KafkaProducerEnhance
 com.lubanops.stresstest.kafka.KafkaConsumerEnhance
+com.lubanops.stresstest.redis.jedis.JedisClusterCRCEnhance
+com.lubanops.stresstest.redis.jedis.JedisKeyEnhance
+com.lubanops.stresstest.redis.jedis.JedisPoolEnhance
+com.lubanops.stresstest.redis.lettuce.LettuceKeyEnhance
+com.lubanops.stresstest.redis.lettuce.LettucePoolEnhance
+com.lubanops.stresstest.redis.redisson.RedissonKeyEnhance
+com.lubanops.stresstest.redis.redisson.RedissonClusterEnhance
+com.lubanops.stresstest.redis.redisson.workaround.RedissonQueueEnhance
+com.lubanops.stresstest.redis.redisson.workaround.RedissonLimiterEnhance
+com.lubanops.stresstest.redis.redisson.workaround.RedissonLimiterDeleteEnhance
+com.lubanops.stresstest.redis.redisson.RedissonObjectEnhance
+com.lubanops.stresstest.db.mongodb.MongoCollectionEnhance
+com.lubanops.stresstest.db.mongodb.MongoDatabaseEnhance

--- a/javamesh-samples/javamesh-threadlocal/threadlocal-plugin/src/main/java/com/lubanops/apm/plugin/threadlocal/ThreadPoolInterceptor.java
+++ b/javamesh-samples/javamesh-threadlocal/threadlocal-plugin/src/main/java/com/lubanops/apm/plugin/threadlocal/ThreadPoolInterceptor.java
@@ -17,7 +17,6 @@ import java.util.concurrent.Callable;
 public class ThreadPoolInterceptor implements InstanceMethodInterceptor {
     @Override
     public void before(Object obj, Method method, Object[] arguments, BeforeResult beforeResult) {
-        System.out.println("ThreadLocal before.");
         for (int i = 0; i < arguments.length; i++) {
             if (arguments[i] instanceof Runnable) {
                 arguments[i] = TtlRunnable.get((Runnable) arguments[i], false, true);
@@ -35,6 +34,6 @@ public class ThreadPoolInterceptor implements InstanceMethodInterceptor {
     }
 
     @Override
-    public void onThrow(Object obj, Method method, Object[] arguments, Throwable t) {
+    public void onThrow(Object obj, Method method, Object[] arguments, Throwable throwable) {
     }
 }


### PR DESCRIPTION
【issue号】#61

【修改内容】全链路压测sdk支持

thread-local : 清理无效日志
online-stresstest : 支持3中redis sdk jedis，redisson，lettuce 分key和分库模式，支持monodb 分表和分库模式，兼容老版本的kafka
【检查者】@fuziye01 @xuezechao-hub @useless223 

【用例描述】暂无

【自测情况】本地测试通过

【影响范围】新增功能模块，无其他模块影响