### PR TITLE
【新功能】core模块添加配置中心服务

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ JavaMesh的打包流程大致分为以下步骤：
 - 如何在插件端使用统一配置[DemoConfigInterceptor](javamesh-samples/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/interceptor/DemoConfigInterceptor.java)
 - 如何在插件端使用心跳功能[DemoHeartBeatService](javamesh-samples/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/service/DemoHeartBeatService.java)
 - 如何在插件端使用链路监控功能[DemoTraceInterceptor](javamesh-samples/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/interceptor/DemoTraceInterceptor.java)
+- 如何在插件端使用配置中心功能[DemoConfigServerService](javamesh-samples/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/service/DemoConfigServerService.java)
 
 ### [示例插件拦截的应用](javamesh-samples/javamesh-example/demo-application)
 

--- a/javamesh-agentcore/javamesh-agentcore-core/pom.xml
+++ b/javamesh-agentcore/javamesh-agentcore-core/pom.xml
@@ -99,6 +99,18 @@
             <version>2.5.0</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.10</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-framework</artifactId>
+            <version>4.3.0</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
     <build>
         <extensions>
@@ -163,6 +175,9 @@
                             <shadedPattern>${shade.common.prefix}.org.aopalliance</shadedPattern>
                         </relocation>
                         <relocation>
+                            <excludes>
+                                <exclude>org.apache.curator.*</exclude>
+                            </excludes>
                             <pattern>org.apache</pattern>
                             <shadedPattern>${shade.common.prefix}.org.apache</shadedPattern>
                         </relocation>

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/common/ConfigServerConfig.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/common/ConfigServerConfig.java
@@ -1,0 +1,20 @@
+package com.huawei.apm.core.common;
+
+import com.huawei.apm.core.config.BaseConfig;
+import com.huawei.apm.core.config.ConfigTypeKey;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@ConfigTypeKey("configServer")
+public class ConfigServerConfig implements BaseConfig {
+
+    private String zkAddress = "127.0.0.1:2181";
+
+    private String zkTimeout = "50000";
+
+    private String zkSleepTime = "1000";
+
+    private String zkRetryTime = "3";
+}

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/service/CoreServiceManager.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/service/CoreServiceManager.java
@@ -39,6 +39,10 @@ public enum CoreServiceManager {
         return (T) services.get(serviceClass.getName());
     }
 
+    public <T> T getService(String className) {
+        return (T) services.get(className);
+    }
+
     private void loadService(CoreService service) {
         Class<? extends CoreService> serviceClass = service.getClass();
         Class<?>[] serviceInterfaces = serviceClass.getInterfaces();
@@ -72,7 +76,7 @@ public enum CoreServiceManager {
                         serviceEntry.getValue().stop();
                     } catch (Exception e) {
                         LOGGER.warning("Failed to stop service [" + serviceEntry.getKey() + "] since: "
-                            + e.getMessage());
+                                + e.getMessage());
                     }
                 }
             }

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/service/configServer/ConfigServer.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/service/configServer/ConfigServer.java
@@ -1,0 +1,9 @@
+package com.huawei.apm.core.service.configServer;
+
+import com.huawei.apm.core.service.CoreService;
+import org.apache.curator.framework.CuratorFramework;
+
+public interface ConfigServer extends CoreService {
+
+    CuratorFramework getClient();
+}

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/service/configServer/zookeeper/ZookeeperServer.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/service/configServer/zookeeper/ZookeeperServer.java
@@ -1,0 +1,7 @@
+package com.huawei.apm.core.service.configServer.zookeeper;
+
+import com.huawei.apm.core.service.configServer.ConfigServer;
+
+public interface ZookeeperServer extends ConfigServer {
+
+}

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/service/configServer/zookeeper/ZookeeperServerImpl.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/service/configServer/zookeeper/ZookeeperServerImpl.java
@@ -1,0 +1,44 @@
+package com.huawei.apm.core.service.configServer.zookeeper;
+
+import com.huawei.apm.core.common.ConfigServerConfig;
+import com.huawei.apm.core.config.ConfigLoader;
+import com.huawei.apm.core.lubanops.bootstrap.log.LogFactory;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class ZookeeperServerImpl implements ZookeeperServer {
+
+    private static final Logger LOGGER = LogFactory.getLogger();
+
+    private static CuratorFramework zkClient;
+
+    private static final ConfigServerConfig configServerConfig = ConfigLoader.getConfig(ConfigServerConfig.class);
+
+    @Override
+    public void start() {
+        try {
+            zkClient = CuratorFrameworkFactory.builder()
+                    .connectString(configServerConfig.getZkAddress())
+                    .sessionTimeoutMs(Integer.parseInt(configServerConfig.getZkTimeout()))
+                    .retryPolicy(new ExponentialBackoffRetry(Integer.parseInt(configServerConfig.getZkSleepTime()), Integer.parseInt(configServerConfig.getZkRetryTime())))
+                    .build();
+            zkClient.start();
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, e.toString());
+        }
+    }
+
+    @Override
+    public void stop() {
+        zkClient.close();
+    }
+
+    @Override
+    public CuratorFramework getClient() {
+        return zkClient;
+    }
+}

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/resources/META-INF/services/com.huawei.apm.core.config.BaseConfig
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/resources/META-INF/services/com.huawei.apm.core.config.BaseConfig
@@ -1,1 +1,2 @@
 com.huawei.apm.core.common.InterceptorChainConfig
+com.huawei.apm.core.common.ConfigServerConfig

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/resources/META-INF/services/com.huawei.apm.core.service.CoreService
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/resources/META-INF/services/com.huawei.apm.core.service.CoreService
@@ -1,2 +1,3 @@
 com.huawei.apm.core.service.heartbeat.HeartbeatServiceImpl
 com.huawei.apm.core.service.send.NettyGatewayClient
+com.huawei.apm.core.service.configServer.zookeeper.ZookeeperServerImpl

--- a/javamesh-samples/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/config/DemoConfig.java
+++ b/javamesh-samples/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/config/DemoConfig.java
@@ -8,6 +8,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import lombok.Getter;
+import lombok.Setter;
 import com.huawei.apm.core.config.BaseConfig;
 import com.huawei.apm.core.config.ConfigFieldKey;
 import com.huawei.apm.core.config.ConfigTypeKey;
@@ -19,8 +21,17 @@ import com.huawei.apm.core.config.ConfigTypeKey;
  * @version 1.0.0
  * @since 2021/10/25
  */
+
+@Getter
+@Setter
 @ConfigTypeKey("demo.test") // 声明前缀
 public class DemoConfig implements BaseConfig {
+
+    /**
+     * 配置中心实现类
+     */
+    private String configServerClassName = "com.huawei.apm.core.service.configServer.zookeeper.ZookeeperServer";
+
     /**
      * 基础类型配置(除byte和char)
      */
@@ -51,54 +62,6 @@ public class DemoConfig implements BaseConfig {
      * 枚举类型
      */
     private DemoType enumType;
-
-    public int getIntField() {
-        return intField;
-    }
-
-    public void setIntField(int intField) {
-        this.intField = intField;
-    }
-
-    public String getStrField() {
-        return strField;
-    }
-
-    public void setStrField(String strField) {
-        this.strField = strField;
-    }
-
-    public short[] getShortArr() {
-        return shortArr;
-    }
-
-    public void setShortArr(short[] shortArr) {
-        this.shortArr = shortArr;
-    }
-
-    public List<Long> getLongList() {
-        return longList;
-    }
-
-    public void setLongList(List<Long> longList) {
-        this.longList = longList;
-    }
-
-    public Map<String, Double> getMap() {
-        return map;
-    }
-
-    public void setMap(Map<String, Double> map) {
-        this.map = map;
-    }
-
-    public DemoType getEnumType() {
-        return enumType;
-    }
-
-    public void setEnumType(DemoType enumType) {
-        this.enumType = enumType;
-    }
 
     @Override
     public String toString() {

--- a/javamesh-samples/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/service/DemoConfigServerService.java
+++ b/javamesh-samples/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/service/DemoConfigServerService.java
@@ -1,0 +1,38 @@
+package com.huawei.example.demo.service;
+
+import com.huawei.apm.core.config.ConfigLoader;
+import com.huawei.apm.core.lubanops.bootstrap.log.LogFactory;
+import com.huawei.apm.core.service.CoreServiceManager;
+import com.huawei.apm.core.service.PluginService;
+import com.huawei.apm.core.service.configServer.zookeeper.ZookeeperServer;
+import com.huawei.example.demo.config.DemoConfig;
+import org.apache.curator.framework.CuratorFramework;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * 本示例展示在插件中使用配置中心，以zookeeper为例
+ */
+public class DemoConfigServerService implements PluginService {
+    private static final Logger LOGGER = LogFactory.getLogger();
+    private static final DemoConfig demoConfig = ConfigLoader.getConfig(DemoConfig.class);
+    private static CuratorFramework zkClient;
+
+
+    @Override
+    public void init() {
+        try {
+            ZookeeperServer zkServer = CoreServiceManager.INSTANCE.getService(demoConfig.getConfigServerClassName());
+            zkClient = zkServer.getClient();
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, e.toString());
+        }
+        System.out.println(zkClient.getState());
+    }
+
+    @Override
+    public void stop() {
+
+    }
+}

--- a/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/config/FlowRecordConfig.java
+++ b/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/config/FlowRecordConfig.java
@@ -11,6 +11,11 @@ import lombok.Setter;
 public class FlowRecordConfig implements BaseConfig {
 
     /**
+     * 配置中心实现类
+     */
+    private String configServerClassName = "com.huawei.apm.core.service.configServer.zookeeper.ZookeeperServer";
+
+    /**
      * 流配置中心 zookeeper地址
      */
     private String zookeeperAddress = "127.0.0.1:2181";


### PR DESCRIPTION
【issue号】#82

【修改原因】
1. 框架不支持配置中心

【修改内容】
1. 框架添加配置服务
2. 核心服务添加支持通过类全限定名字符串获取实例
3. 配置服务支持zookeeper
4. demo插件添加使用配置服务示例
5. README添加如何使用配置链接
6. 录制插件通过配置服务加载配置

【检查者】@fuziye01 @HapThorin

【用例描述】暂无

【自测情况】本地测试通过

【影响范围】
1. README文件示例说明新增如何使用配置服务链接
2. demo插件新增使用配置服务示例
3. 录制插件使用配置服务加载配置