### PR TITLE
【CI】添加actions配置，开启github自动构建功能

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,31 @@
+name: Java CI with Maven
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+          cache: maven
+      - name: Build with Maven
+        run: |
+          mvn -B package -DskipTests --file pom.xml
+          mkdir ${{ github.workspace }}/package
+          cp ${{ github.workspace }}/javamesh-agent-2.0.5.tar ${{ github.workspace }}/package
+      - name: upload package
+        uses: actions/upload-artifact@v1
+        with:
+          name: java-mesh
+          path: ${{ github.workspace }}/package


### PR DESCRIPTION
【issue号】#86

【修改原因】

1. 仓库没有自动构建出包能力

【修改内容】

1. 添加actions配置文件
【检查者】@fuziye01 @HapThorin

【用例描述】暂无

【自测情况】本地测试通过

【影响范围】

1. 支持个人fork CI构建
2. 支持合入master分支构建