### PR TITLE
【功能】抽出抛出业务异常入口

### DIFF
--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/agent/enhancer/AbstractAroundEnhancer.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/agent/enhancer/AbstractAroundEnhancer.java
@@ -2,6 +2,7 @@ package com.huawei.apm.core.agent.enhancer;
 
 import com.huawei.apm.core.agent.common.BeforeResult;
 import com.huawei.apm.core.agent.common.OverrideArgumentsCall;
+import com.huawei.apm.core.exception.BizException;
 import com.huawei.apm.core.lubanops.bootstrap.Interceptor;
 
 import java.lang.reflect.Method;
@@ -47,6 +48,17 @@ public abstract class AbstractAroundEnhancer  extends OriginEnhancer {
             onFinally(origin, arguments, method, result);
         }
         return result;
+    }
+
+    /**
+     * 抛出业务异常
+     *
+     * @param throwable 拦截器执行异常
+     */
+    protected void throwBizException(Throwable throwable) {
+        if (throwable instanceof BizException) {
+            throw (BizException) throwable;
+        }
     }
 
     /**

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/agent/enhancer/StaticMethodEnhancer.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/agent/enhancer/StaticMethodEnhancer.java
@@ -88,6 +88,7 @@ public final class StaticMethodEnhancer extends AbstractAroundEnhancer {
         } catch (Throwable t) {
             LOGGER.severe(String.format("An error occurred before [{%s}#{%s}] in interceptor [{%s}]: [{%s}]",
                     clazz.getName(), method.getName(), interceptor.getClass().getName(), t.getMessage()));
+            throwBizException(t);
         }
     }
 
@@ -102,6 +103,7 @@ public final class StaticMethodEnhancer extends AbstractAroundEnhancer {
             LOGGER.severe(String.format("An error occurred while handling throwable thrown by"
                             + " [{%s}#{%s}] in interceptor [{%s}]: [{%s}].",
                     clazz.getName(), method.getName(), interceptor.getClass().getName(), t.getMessage()));
+            throwBizException(t);
         }
     }
 
@@ -116,6 +118,7 @@ public final class StaticMethodEnhancer extends AbstractAroundEnhancer {
         } catch (Throwable t) {
             LOGGER.severe(String.format("An error occurred after [{%s}#{%s}] in interceptor [{%s}]: [{%s}].",
                     clazz.getName(), method.getName(), interceptor.getClass().getName(), t.getMessage()));
+            throwBizException(t);
         }
         return returnResult;
     }

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/exception/BizException.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/exception/BizException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ */
+
+package com.huawei.apm.core.exception;
+
+/**
+ * 业务异常
+ * 抛出异常到调用方，即抛给用户应用
+ *
+ * 可参考{@see com.huawei.flowcontrol.exception.FlowControlException}
+ *
+ * @author zhouss
+ * @since 2021-11-12
+ */
+public class BizException extends RuntimeException{
+
+    public BizException(String msg) {
+        super(msg);
+    }
+
+    public BizException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public BizException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/javamesh-samples/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/DubboInterceptor.java
+++ b/javamesh-samples/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/DubboInterceptor.java
@@ -7,7 +7,7 @@ import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
 import com.huawei.apm.core.agent.common.BeforeResult;
 import com.huawei.apm.core.agent.interceptor.InstanceMethodInterceptor;
-import com.huawei.apm.core.exception.FlowControlException;
+import com.huawei.flowcontrol.exception.FlowControlException;
 import com.huawei.flowcontrol.util.SentinelRuleUtil;
 import com.huawei.flowcontrol.util.TraceEntryUtils;
 
@@ -44,11 +44,7 @@ public abstract class DubboInterceptor implements InstanceMethodInterceptor {
     }
 
     protected String getResourceName(String interfaceName, String methodName) {
-        StringBuilder buf = new StringBuilder();
-        buf.append(interfaceName)
-            .append(":")
-            .append(methodName);
-        return buf.toString();
+        return interfaceName + ":" + methodName;
     }
 
     protected void handleBlockException(BlockException ex, String resourceName, BeforeResult result, String type) {

--- a/javamesh-samples/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/exception/FlowControlException.java
+++ b/javamesh-samples/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/exception/FlowControlException.java
@@ -2,7 +2,9 @@
  * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
  */
 
-package com.huawei.apm.core.exception;
+package com.huawei.flowcontrol.exception;
+
+import com.huawei.apm.core.exception.BizException;
 
 /**
  * 流控异常类
@@ -11,7 +13,7 @@ package com.huawei.apm.core.exception;
  * @author liyi
  * @since 1.0 2020-10-10
  */
-public class FlowControlException extends RuntimeException {
+public class FlowControlException extends BizException {
     /**
      * 通用自定义类构造方法
      *


### PR DESCRIPTION
【issue号】#89
【修改原因】流控插件存在需抛出异常到业务层的场景，此处只针对流控生效；针对这块抽象业务异常，提供其他有类似场景插件业务异常抛出入口
【修改内容】
1、新增BizException，所有需抛出业务异常的插件端，均需要继承该类；
2、定义在core的FlowControlException已迁移到流控插件
【检查者】@beetle-man @fuziye01 @xuezechao-hub @HapThorin

【用例描述】暂无

【自测情况】本地测试通过

【影响范围】流控能力