### PR TITLE
【bug】录制插件删除多余依赖

### DIFF
--- a/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/pom.xml
+++ b/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/pom.xml
@@ -181,11 +181,6 @@
             <version>3.1.0</version>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>com.huawei.javamesh</groupId>
-            <artifactId>javamesh-backend</artifactId>
-            <version>1.0.0</version>
-        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
【issue号】#91

【修改原因】

1. 录制插件存在多余依赖配置

【修改内容】

1. pom文件删除backend依赖配置

【检查者】@fuziye01 @HapThorin

【用例描述】暂无

【自测情况】本地测试通过

【影响范围】无影响