### PR TITLE
【bug修复】修复插件配置文件不存在时获取到的插件配置对象为空的问题

### DIFF
--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/exception/IllegalConfigException.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/exception/IllegalConfigException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved.
+ */
+
+package com.huawei.apm.core.exception;
+
+import java.util.Locale;
+
+import com.huawei.apm.core.config.common.BaseConfig;
+
+/**
+ * 非法配置异常，配置对象缺少默认的构造函数
+ *
+ * @author HapThorin
+ * @version 1.0.0
+ * @since 2021/11/18
+ */
+public class IllegalConfigException extends RuntimeException {
+    public IllegalConfigException(Class<? extends BaseConfig> cls) {
+        super(String.format(Locale.ROOT, "Unable to create default instance of %s, please check. ", cls.getName()));
+    }
+}

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/plugin/config/PluginConfigManager.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/plugin/config/PluginConfigManager.java
@@ -5,10 +5,17 @@
 package com.huawei.apm.core.plugin.config;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.logging.Logger;
 
 import com.huawei.apm.core.agent.interceptor.InterceptorChainManager;
 import com.huawei.apm.core.config.ConfigManager;
 import com.huawei.apm.core.config.common.BaseConfig;
+import com.huawei.apm.core.config.utils.ConfigKeyUtil;
+import com.huawei.apm.core.exception.IllegalConfigException;
+import com.huawei.apm.core.lubanops.bootstrap.log.LogFactory;
 import com.huawei.apm.core.util.FileUtil;
 
 /**
@@ -19,7 +26,20 @@ import com.huawei.apm.core.util.FileUtil;
  * @since 2021/11/12
  */
 public class PluginConfigManager extends ConfigManager {
+    /**
+     * 日志
+     */
+    private static final Logger LOGGER = LogFactory.getLogger();
+
+    /**
+     * 插件配置文件名
+     */
     private static final String CONFIG_FILE_NAME = "config.yaml";
+
+    /**
+     * 默认配置对象集
+     */
+    private static final Map<String, PluginConfig> DEFAULT_CONFIG_MAP = new HashMap<String, PluginConfig>();
 
     /**
      * 加载插件服务包配置
@@ -45,5 +65,56 @@ public class PluginConfigManager extends ConfigManager {
                         }
                     }
                 });
+    }
+
+    /**
+     * 插件端专用的获取配置方法，当插件配置文件不存在时，插件配置将会不初始化出来，该方法将针对这一情况返回一个默认对象
+     *
+     * @param cls 插件配置类
+     * @param <R> 插件配置类型
+     * @return 插件配置实例
+     */
+    public static <R extends PluginConfig> R getPluginConfig(Class<R> cls) {
+        final R config = ConfigManager.getConfig(cls);
+        if (config != null) {
+            return config;
+        }
+        LOGGER.fine(String.format(Locale.ROOT, "Missing config file of %s, use default instance. ", cls.getName()));
+        return getDefaultPluginConfig(cls);
+    }
+
+    /**
+     * 获取默认的配置对象
+     *
+     * @param cls 插件配置类
+     * @param <R> 插件配置类型
+     * @return 默认配置对象
+     */
+    private static synchronized <R extends PluginConfig> R getDefaultPluginConfig(Class<R> cls) {
+        final String typeKey = ConfigKeyUtil.getTypeKey(cls);
+        final PluginConfig pluginConfig = DEFAULT_CONFIG_MAP.get(typeKey);
+        if (pluginConfig != null) {
+            return (R) pluginConfig;
+        }
+        LOGGER.fine(String.format(Locale.ROOT, "Create default instance of %s. ", cls.getName()));
+        final R defaultConfig = createPluginConfig(cls);
+        DEFAULT_CONFIG_MAP.put(typeKey, defaultConfig);
+        return defaultConfig;
+    }
+
+    /**
+     * 创建默认配置对象
+     *
+     * @param cls 插件配置类
+     * @param <R> 插件配置类型
+     * @return 默认配置对象
+     */
+    private static <R extends PluginConfig> R createPluginConfig(Class<R> cls) {
+        try {
+            return cls.newInstance();
+        } catch (InstantiationException ignored) {
+        } catch (IllegalAccessException ignored) {
+        }
+        throw new IllegalConfigException(cls);
     }
 }

--- a/javamesh-samples/javamesh-example/demo-application/pom.xml
+++ b/javamesh-samples/javamesh-example/demo-application/pom.xml
@@ -7,4 +7,8 @@
     <groupId>com.huawei.javamesh</groupId>
     <artifactId>demo-application</artifactId>
     <version>1.0.0</version>
+
+    <build>
+        <finalName>${artifactId}</finalName>
+    </build>
 </project>

--- a/javamesh-samples/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/interceptor/DemoConfigInterceptor.java
+++ b/javamesh-samples/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/interceptor/DemoConfigInterceptor.java
@@ -7,8 +7,8 @@ package com.huawei.example.demo.interceptor;
 import java.lang.reflect.Method;
 
 import com.huawei.apm.core.agent.common.BeforeResult;
-import com.huawei.apm.core.config.ConfigManager;
 import com.huawei.apm.core.agent.interceptor.StaticMethodInterceptor;
+import com.huawei.apm.core.plugin.config.PluginConfigManager;
 import com.huawei.example.demo.config.DemoConfig;
 
 /**
@@ -24,7 +24,7 @@ public class DemoConfigInterceptor implements StaticMethodInterceptor {
     @Override
     public void before(Class<?> clazz, Method method, Object[] arguments, BeforeResult beforeResult) throws Exception {
         System.out.println(clazz.getSimpleName() + ": [DemoConfigInterceptor]-before");
-        config = ConfigManager.getConfig(DemoConfig.class);
+        config = PluginConfigManager.getPluginConfig(DemoConfig.class);
     }
 
     @Override

--- a/javamesh-samples/javamesh-example/demo-service/src/main/java/com/huawei/example/demo/service/DemoComplexServiceImpl.java
+++ b/javamesh-samples/javamesh-example/demo-service/src/main/java/com/huawei/example/demo/service/DemoComplexServiceImpl.java
@@ -6,8 +6,8 @@ package com.huawei.example.demo.service;
 
 import java.util.logging.Logger;
 
-import com.huawei.apm.core.config.ConfigManager;
 import com.huawei.apm.core.lubanops.bootstrap.log.LogFactory;
+import com.huawei.apm.core.plugin.config.PluginConfigManager;
 import com.huawei.apm.core.service.ServiceManager;
 import com.huawei.example.demo.config.DemoConfig;
 import com.huawei.example.demo.config.DemoServiceConfig;
@@ -45,9 +45,9 @@ public class DemoComplexServiceImpl implements DemoComplexService {
     @Override
     public void passiveFunc() {
         System.out.println("[DemoComplexService]-passiveFunc");
-        final DemoServiceConfig serviceConfig = ConfigManager.getConfig(DemoServiceConfig.class);
+        final DemoServiceConfig serviceConfig = PluginConfigManager.getPluginConfig(DemoServiceConfig.class);
         System.out.println(getClass().getSimpleName() + ": " + serviceConfig);
-        final DemoConfig demoConfig = ConfigManager.getConfig(DemoConfig.class);
+        final DemoConfig demoConfig = PluginConfigManager.getPluginConfig(DemoConfig.class);
         System.out.println(getClass().getSimpleName() + ": " + demoConfig);
         logger.info("[DemoService]-passiveFunc");
     }

--- a/javamesh-samples/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/config/KafkaConnectBySslSwitch.java
+++ b/javamesh-samples/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/config/KafkaConnectBySslSwitch.java
@@ -1,6 +1,6 @@
 package com.huawei.flowcontrol.core.config;
 
-import com.huawei.apm.core.config.ConfigManager;
+import com.huawei.apm.core.plugin.config.PluginConfigManager;
 
 import java.util.Properties;
 
@@ -14,7 +14,7 @@ public class KafkaConnectBySslSwitch {
      * @param properties Properties对象
      */
     public static void delKey(Properties properties) {
-        final FlowControlConfig flowControlConfig = ConfigManager.getConfig(FlowControlConfig.class);
+        final FlowControlConfig flowControlConfig = PluginConfigManager.getPluginConfig(FlowControlConfig.class);
         if (!flowControlConfig.isKafkaIsSsl()) {
             properties.remove(ConfigConst.KAFKA_JAAS_CONFIG_CONST);
             properties.remove(ConfigConst.KAFKA_SASL_MECHANISM_CONST);

--- a/javamesh-samples/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/PluginConfigUtil.java
+++ b/javamesh-samples/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/PluginConfigUtil.java
@@ -5,8 +5,8 @@
 package com.huawei.flowcontrol.core.util;
 
 import com.alibaba.csp.sentinel.log.RecordLog;
-import com.huawei.apm.core.config.ConfigManager;
 import com.huawei.apm.core.lubanops.bootstrap.log.LogFactory;
+import com.huawei.apm.core.plugin.config.PluginConfigManager;
 import com.huawei.flowcontrol.core.config.CommonConst;
 import com.huawei.flowcontrol.core.config.ConfigConst;
 import com.huawei.flowcontrol.core.config.FlowControlConfig;
@@ -35,7 +35,7 @@ public class PluginConfigUtil {
 
     static {
         // 待后续接入配置中心
-        setPropertiesFromFlowControlConfig(ConfigManager.getConfig(FlowControlConfig.class));
+        setPropertiesFromFlowControlConfig(PluginConfigManager.getPluginConfig(FlowControlConfig.class));
     }
 
     /**
@@ -85,7 +85,7 @@ public class PluginConfigUtil {
         }
         try {
             String rootInfo = new String(zkClient.getData().forPath(
-                ConfigManager.getConfig(FlowControlConfig.class).getConfigZookeeperPath() + CommonConst.SLASH_SIGN + active), Charset.forName("UTF-8"));
+                    PluginConfigManager.getPluginConfig(FlowControlConfig.class).getConfigZookeeperPath() + CommonConst.SLASH_SIGN + active), Charset.forName("UTF-8"));
             String[] configData = rootInfo.split(CommonConst.NEWLINE_SIGN);
             for (String line : configData) {
                 String[] values = line.split(CommonConst.EQUAL_SIGN);

--- a/javamesh-samples/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/ZookeeperConnectionEnum.java
+++ b/javamesh-samples/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/ZookeeperConnectionEnum.java
@@ -5,7 +5,7 @@
 package com.huawei.flowcontrol.core.util;
 
 import com.alibaba.csp.sentinel.log.RecordLog;
-import com.huawei.apm.core.config.ConfigManager;
+import com.huawei.apm.core.plugin.config.PluginConfigManager;
 import com.huawei.flowcontrol.core.config.CommonConst;
 import com.huawei.flowcontrol.core.config.FlowControlConfig;
 import org.apache.curator.framework.CuratorFramework;
@@ -27,7 +27,7 @@ public enum ZookeeperConnectionEnum {
     private CuratorFramework client;
 
     ZookeeperConnectionEnum() {
-        final FlowControlConfig flowControlConfig = ConfigManager.getConfig(FlowControlConfig.class);
+        final FlowControlConfig flowControlConfig = PluginConfigManager.getPluginConfig(FlowControlConfig.class);
         RecordLog.info("start connect zookeeper, address: [{}]", flowControlConfig.getSentinelZookeeperAddress());
 
         // 创建 CuratorFrameworkImpl实例

--- a/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/utils/PluginConfigUtil.java
+++ b/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/utils/PluginConfigUtil.java
@@ -4,7 +4,7 @@
 
 package com.huawei.flowrecord.utils;
 
-import com.huawei.apm.core.config.ConfigManager;
+import com.huawei.apm.core.plugin.config.PluginConfigManager;
 import com.huawei.flowrecord.config.FlowRecordConfig;
 import org.apache.skywalking.apm.agent.core.logging.api.ILog;
 import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
@@ -18,7 +18,7 @@ public class PluginConfigUtil {
 
     static {
         try {
-            flowRecordConfig = ConfigManager.getConfig(FlowRecordConfig.class);
+            flowRecordConfig = PluginConfigManager.getPluginConfig(FlowRecordConfig.class);
         } catch (Exception e) {
             LOGGER.info("[flowrecord]: cannot get properties");
         }

--- a/javamesh-samples/javamesh-route/label-plugin/src/main/java/com/huawei/route/label/LabelInitServiceImpl.java
+++ b/javamesh-samples/javamesh-route/label-plugin/src/main/java/com/huawei/route/label/LabelInitServiceImpl.java
@@ -4,7 +4,7 @@
 
 package com.huawei.route.label;
 
-import com.huawei.apm.core.config.ConfigManager;
+import com.huawei.apm.core.plugin.config.PluginConfigManager;
 import com.huawei.apm.core.plugin.service.PluginService;
 
 /**
@@ -16,7 +16,7 @@ import com.huawei.apm.core.plugin.service.PluginService;
 public class LabelInitServiceImpl implements PluginService {
     @Override
     public void start() {
-        final LabelConfig config = ConfigManager.getConfig(LabelConfig.class);
+        final LabelConfig config = PluginConfigManager.getPluginConfig(LabelConfig.class);
         if (config.isLabelOpen()) {
             LabelValidService.INSTANCE.start(config.getPort());
         }

--- a/javamesh-samples/javamesh-route/report-plugin/src/main/java/com/huawei/route/report/ReporterPluginInitServiceImpl.java
+++ b/javamesh-samples/javamesh-route/report-plugin/src/main/java/com/huawei/route/report/ReporterPluginInitServiceImpl.java
@@ -4,8 +4,8 @@
 
 package com.huawei.route.report;
 
-import com.huawei.apm.core.config.ConfigManager;
 import com.huawei.apm.core.lubanops.bootstrap.log.LogFactory;
+import com.huawei.apm.core.plugin.config.PluginConfigManager;
 import com.huawei.apm.core.plugin.service.PluginService;
 import com.huawei.route.common.factory.NamedThreadFactory;
 import com.huawei.route.common.label.observers.LabelObservers;
@@ -62,7 +62,7 @@ public class ReporterPluginInitServiceImpl implements PluginService {
 
     @Override
     public void start() {
-        final ReporterConfig config = ConfigManager.getConfig(ReporterConfig.class);
+        final ReporterConfig config = PluginConfigManager.getPluginConfig(ReporterConfig.class);
         // 注册标签库修改监听
         LabelObservers.INSTANCE.registerLabelObservers(new LdcConfigurationObserver());
         final ScheduledThreadPoolExecutor scheduledThreadPoolExecutor = new ScheduledThreadPoolExecutor(1, new NamedThreadFactory("registerMessage-sender"));


### PR DESCRIPTION
【issue号】#112

【修改原因】插件配置文件不存在时获取到的插件配置对象为空

【修改内容】修复插件配置文件不存在时获取到的插件配置对象为空的问题

【检查者】@fuziye01 @3838438abcd @xuezechao-hub @beetle-man

【用例描述】暂无用例

【自测情况】本地测试通过

【影响范围】所有插件获取配置的api调整为PluginConfigManager#getPluginConfig @3838438abcd @xuezechao-hub @beetle-man