### PR TITLE
框架日志采用logback统一

### DIFF
--- a/javamesh-agentcore/javamesh-agentcore-core/pom.xml
+++ b/javamesh-agentcore/javamesh-agentcore-core/pom.xml
@@ -91,10 +91,6 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <version>2.5.0</version>
@@ -103,7 +99,52 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
             <version>3.6.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <version>1.7.32</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>1.2.6</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>2.14.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+            <version>1.7.32</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>1.7.32</version>
+        </dependency>
+        <dependency>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+            <version>2.12.1</version>
         </dependency>
     </dependencies>
     <build>
@@ -149,6 +190,10 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <configuration>
                     <relocations>
+                        <relocation>
+                            <pattern>ch.qos.logback</pattern>
+                            <shadedPattern>${shade.common.prefix}.ch.qos.logback</shadedPattern>
+                        </relocation>
                         <relocation>
                             <pattern>net.bytebuddy</pattern>
                             <shadedPattern>${shade.common.prefix}.net.bytebuddy</shadedPattern>
@@ -243,6 +288,12 @@
                                     <directory>${config.source.dir}/${profile.id}</directory>
                                     <includes>
                                         <include>plugins.yaml</include>
+                                    </includes>
+                                </resource>
+                                <resource>
+                                    <directory>${config.source.dir}/</directory>
+                                    <includes>
+                                        <include>logback.xml</include>
                                     </includes>
                                 </resource>
                             </resources>

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/AgentCoreEntrance.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/AgentCoreEntrance.java
@@ -10,9 +10,12 @@ import java.util.Map;
 import com.huawei.apm.core.agent.ByteBuddyAgentBuilder;
 import com.huawei.apm.core.common.PathIndexer;
 import com.huawei.apm.core.config.ConfigManager;
+import com.huawei.apm.core.log.LogBackInit;
+import com.huawei.apm.core.lubanops.bootstrap.log.LogFactory;
 import com.huawei.apm.core.lubanops.core.BootStrapImpl;
 import com.huawei.apm.core.plugin.PluginManager;
 import com.huawei.apm.core.service.ServiceManager;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 
 /**
  * agent core入口
@@ -30,6 +33,10 @@ public class AgentCoreEntrance {
      * @throws Exception agent core执行异常
      */
     public static void run(Map<String, Object> argsMap, Instrumentation instrumentation) throws Exception {
+
+        // 初始化日志
+        LogBackInit.init((String) argsMap.get(PathIndexer.JAVAMESH_LOGBACK_SETTING_FILE));
+
         // 初始化路径
         PathIndexer.build(argsMap);
         // 初始化统一配置

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/common/PathIndexer.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/common/PathIndexer.java
@@ -39,6 +39,11 @@ public class PathIndexer {
     public static String JAVAMESH_PLUGIN_PACKAGE_DIR = "javamesh.plugin.package.dir";
 
     /**
+     * logback配置的键
+     */
+    public static String JAVAMESH_LOGBACK_SETTING_FILE = "javamesh.log.setting.file";
+
+    /**
      * 配置文件
      */
     private static File configFile;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/log/LogBackInit.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/apm/core/log/LogBackInit.java
@@ -1,0 +1,24 @@
+package com.huawei.apm.core.log;
+
+
+import com.huawei.apm.core.lubanops.bootstrap.log.LogFactory;
+import org.slf4j.bridge.SLF4JBridgeHandler;
+
+public class LogBackInit {
+
+    private static final String LOGBACK_SETTING_PATH_KEY = "logback.configurationFile";
+
+    public static void init(String logbackSettingPath) {
+        // 设置slf4j 日志 handle
+        String defaultLogbackSettingPath = System.getProperty(LOGBACK_SETTING_PATH_KEY);
+        System.setProperty(LOGBACK_SETTING_PATH_KEY, logbackSettingPath);
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+        SLF4JBridgeHandler.install();
+        LogFactory.setLogger(java.util.logging.Logger.getLogger("java-mesh"));
+        if (defaultLogbackSettingPath != null) {
+            System.setProperty(LOGBACK_SETTING_PATH_KEY, defaultLogbackSettingPath);
+        } else {
+            System.clearProperty(logbackSettingPath);
+        }
+    }
+}

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/resources/config/logback.xml
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/resources/config/logback.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration scan="true">
+
+    <!-- 定义日志文件 输出位置 -->
+    <property name="log.home_dir" value="./logs"/>
+    <property name="log.app_name" value="java-mesh"/>
+    <!-- 日志最大的历史 30天 -->
+    <property name="log.maxHistory" value="30"/>
+    <property name="log.level" value="info"/>
+    <property name="log.maxSize" value="5MB" />
+
+    <!-- ConsoleAppender 控制台输出日志 -->
+    <appender name="CONSOLE" class="com.huawei.ch.qos.logback.core.ConsoleAppender">
+        <filter class="com.huawei.ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>
+                <!-- 设置日志输出格式 -->
+                %d{yyyy-MM-dd HH:mm:ss.SSS} [%-5level] [%thread] %logger - %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <!--设置一个向上传递的appender,所有级别的日志都会输出-->
+    <appender name="app" class="com.huawei.ch.qos.logback.core.rolling.RollingFileAppender">
+        <rollingPolicy class="com.huawei.ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${log.home_dir}/app/%d{yyyy-MM-dd}/${log.app_name}-%i.log</fileNamePattern>
+            <maxHistory>${log.maxHistory}</maxHistory>
+            <MaxFileSize>${log.maxSize}</MaxFileSize>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5level] %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- root级别   DEBUG -->
+    <root>
+        <!-- 打印debug级别日志及以上级别日志 -->
+        <level value="${log.level}"/>
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="app" />
+    </root>
+
+</configuration>

--- a/javamesh-agentcore/javamesh-agentcore-premain/src/main/java/com/huawei/apm/premain/common/BootArgsBuilder.java
+++ b/javamesh-agentcore/javamesh-agentcore-premain/src/main/java/com/huawei/apm/premain/common/BootArgsBuilder.java
@@ -180,5 +180,6 @@ public abstract class BootArgsBuilder {
         argsMap.put(PathIndexer.JAVAMESH_CONFIG_FILE, PathDeclarer.getConfigPath());
         argsMap.put(PathIndexer.JAVAMESH_PLUGIN_SETTING_FILE, PathDeclarer.getPluginSettingPath());
         argsMap.put(PathIndexer.JAVAMESH_PLUGIN_PACKAGE_DIR, PathDeclarer.getPluginPackagePath());
+        argsMap.put(PathIndexer.JAVAMESH_LOGBACK_SETTING_FILE, PathDeclarer.getLogbackSettingPath());
     }
 }

--- a/javamesh-agentcore/javamesh-agentcore-premain/src/main/java/com/huawei/apm/premain/common/PathDeclarer.java
+++ b/javamesh-agentcore/javamesh-agentcore-premain/src/main/java/com/huawei/apm/premain/common/PathDeclarer.java
@@ -78,4 +78,13 @@ public class PathDeclarer {
     public static String getLubanPluginsPath() {
         return getPluginPackagePath() + File.separatorChar + "luban";
     }
+
+    /**
+     * 获取logback日志配置
+     *
+     * @return logback日志配置
+     */
+    public static String getLogbackSettingPath() {
+        return getAgentPath() + File.separatorChar + "config" + File.separatorChar + "logback.xml";
+    }
 }


### PR DESCRIPTION
【issue号】#114

【修改原因】

1. premain模块 和 core 模块采用不同的日志实现
2. 日志配置无法统一管理，无法出包后进行修改

【修改内容】

1. core模块采用jul-to-slf4j桥接包将jul日志交由slf4j管理
2. core模块采用logback实现slf4j日志接口
3. 编译后config目录添加logback配置文件
4. 框架日志输出目录为java-mesh目录下logs目录，按照级别，日期进行分类。

【检查者】@fuziye01 @HapThorin

【用例描述】暂无

【自测情况】本地测试通过

【影响范围】

1. premain模块日志输出到文件中
2. core日志在控制台和文件中同步打印