### PR TITLE
解决录制插件录制流量入参错误的问题

### DIFF
--- a/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/domain/HttpRequestEntity.java
+++ b/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/domain/HttpRequestEntity.java
@@ -26,5 +26,5 @@ public class HttpRequestEntity {
     /**
      * 请求json字符串
      */
-    private String httpRequestBody;
+    private Map<String, String[]> httpRequestBody;
 }

--- a/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/http/v4/HttpServerInterceptor.java
+++ b/javamesh-samples/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/http/v4/HttpServerInterceptor.java
@@ -69,7 +69,7 @@ public class HttpServerInterceptor implements InstanceMethodInterceptor {
 
         httpRequestEntity.setMethod(httpServletRequest.getMethod());
         httpRequestEntity.setHeadMap(headerMap);
-        httpRequestEntity.setHttpRequestBody(httpServletRequest.toString());
+        httpRequestEntity.setHttpRequestBody(httpServletRequest.getParameterMap());
 
         HttpServletResponse httpServletResponse = (HttpServletResponse) arguments[1];
         HttpResponseEntity httpResponseEntity = new HttpResponseEntity();


### PR DESCRIPTION
【issue号】#116

【修改原因】

1. 录制插件流量入参录制错误

【修改内容】

1. 录制插件流量请求体格式由string改为 map
2. 入参录制改为调用获取请求参数api

【检查者】@fuziye01 @HapThorin

【用例描述】暂无

【自测情况】本地测试通过

【影响范围】

1. 录制插件录制流量请求体类型由string改为map
2. 录制插件获取请求参数方式修改