### PR TITLE
启动后luban报错问题修改

### DIFF
--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/proto/Message.proto
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/proto/Message.proto
@@ -26,6 +26,8 @@ message ServiceData{
     PLUGIN_FLOW_RECORD_DATA = 3;
     SERVER_MONITOR = 4;
     ORACLE_JVM_MONITOR = 5;
+    AGENT_MONITOR = 8;
+    AGENT_SPAN_EVENT = 9;
   }
   DataType dataType = 1;
   bytes data = 2;

--- a/javamesh-agentcore/javamesh-agentcore-premain/src/main/resources/config/bootstrap.properties
+++ b/javamesh-agentcore/javamesh-agentcore-premain/src/main/resources/config/bootstrap.properties
@@ -1,4 +1,4 @@
-master.address=http://127.0.0.1:8082
+master.address=http://127.0.0.1:8900
 #master.address=https://100.95.151.151:443
 #access.address=127.0.0.1:8081
 log.level=debug

--- a/javamesh-backend/pom.xml
+++ b/javamesh-backend/pom.xml
@@ -69,6 +69,31 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>fastjson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/javamesh-backend/src/main/java/com/huawei/apm/backend/common/conf/KafkaConf.java
+++ b/javamesh-backend/src/main/java/com/huawei/apm/backend/common/conf/KafkaConf.java
@@ -54,4 +54,10 @@ public class KafkaConf {
 
     @Value("${kafka.agent-registration.topic}")
     private String topicAgentRegistration;
+
+    @Value("${kafka.agent-monitor.topic}")
+    private String topicAgentMonitor;
+
+    @Value("${kafka.agent-span-event.topic}")
+    private String topicAgentSpanEvent;
 }

--- a/javamesh-backend/src/main/java/com/huawei/apm/backend/entity/Address.java
+++ b/javamesh-backend/src/main/java/com/huawei/apm/backend/entity/Address.java
@@ -1,0 +1,38 @@
+package com.huawei.apm.backend.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Address {
+    /**
+     * 主机名，可以是ip也可以是域名
+     */
+    private String host;
+
+    /**
+     * 端口
+     */
+    private int port;
+
+    /**
+     * 安全端口
+     */
+    private int sport;
+
+    /**
+     * inner或者outer，代表是内网还是外网，地址优先链接内网的
+     */
+    private AddressType type;
+
+    /**
+     * 内外
+     */
+    private AddressScope scope;
+
+    /*
+     * 协议,当前只支持ws
+     */
+    private Protocol protocol;
+}

--- a/javamesh-backend/src/main/java/com/huawei/apm/backend/entity/AddressScope.java
+++ b/javamesh-backend/src/main/java/com/huawei/apm/backend/entity/AddressScope.java
@@ -1,0 +1,21 @@
+package com.huawei.apm.backend.entity;
+
+public enum AddressScope {
+    /*
+    内部地址
+     */
+    inner,
+
+    /**
+     * 对外的地址
+     */
+    outer;
+
+    public static AddressScope getValue(String s) {
+        try {
+            return AddressScope.valueOf(s);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/javamesh-backend/src/main/java/com/huawei/apm/backend/entity/AddressType.java
+++ b/javamesh-backend/src/main/java/com/huawei/apm/backend/entity/AddressType.java
@@ -1,0 +1,17 @@
+package com.huawei.apm.backend.entity;
+
+public enum AddressType {
+    /**
+     * acess服务器的地址
+     */
+    access;
+
+    public static AddressType getValue(String s) {
+
+        try {
+            return AddressType.valueOf(s);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/javamesh-backend/src/main/java/com/huawei/apm/backend/entity/HeartBeatResult.java
+++ b/javamesh-backend/src/main/java/com/huawei/apm/backend/entity/HeartBeatResult.java
@@ -1,0 +1,42 @@
+package com.huawei.apm.backend.entity;
+
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class HeartBeatResult extends Result {
+    /**
+     * 下一次心跳的周期
+     */
+    private Integer heartBeatInterval;
+
+    /**
+     * 附属信息，收到这个信息后，原封不动得通过数据上报
+     */
+    private Map<String, String> attachment;
+
+    private List<MonitorItem> monitorItemList;
+
+    /**
+     * 系统属性
+     */
+    private Map<String, String> systemProperties;
+
+    /**
+     * access的地址描述
+     */
+    private List<Address> accessAddressList;
+
+    /**
+     * 实例状态0 代表ok， 1代表disabled
+     */
+    private Integer instanceStatus;
+
+    /**
+     * 对结果进行md5计算，如果内容变化了就下发新的配置
+     */
+    private String md5;
+}

--- a/javamesh-backend/src/main/java/com/huawei/apm/backend/entity/MonitorItem.java
+++ b/javamesh-backend/src/main/java/com/huawei/apm/backend/entity/MonitorItem.java
@@ -1,0 +1,21 @@
+package com.huawei.apm.backend.entity;
+
+import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MonitorItem {
+    private String collectorName;
+
+    private Integer interval;
+
+    private Integer collectorId;
+
+    private Long monitorItemId;
+
+    private Integer status;
+
+    private Map<String, String> parameters;
+}

--- a/javamesh-backend/src/main/java/com/huawei/apm/backend/entity/Protocol.java
+++ b/javamesh-backend/src/main/java/com/huawei/apm/backend/entity/Protocol.java
@@ -1,0 +1,31 @@
+package com.huawei.apm.backend.entity;
+
+public enum Protocol {
+    /**
+     * websocket
+     */
+    WS("ws", "wss"),
+    /**
+     * http
+     */
+    HTTP("http", "https"),
+    ;
+
+    private String value;
+
+    private String secure;
+
+    Protocol(String value, String secure) {
+        this.value = value;
+        this.secure = secure;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String getSecure() {
+        return secure;
+    }
+
+}

--- a/javamesh-backend/src/main/java/com/huawei/apm/backend/entity/RegisterResult.java
+++ b/javamesh-backend/src/main/java/com/huawei/apm/backend/entity/RegisterResult.java
@@ -1,0 +1,20 @@
+package com.huawei.apm.backend.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RegisterResult extends Result {
+
+    private Long appId;
+
+    private Long envId;
+
+    private int domainId;
+
+    private String agentVersion;
+
+    private Long instanceId;
+}
+

--- a/javamesh-backend/src/main/java/com/huawei/apm/backend/entity/Result.java
+++ b/javamesh-backend/src/main/java/com/huawei/apm/backend/entity/Result.java
@@ -1,0 +1,20 @@
+package com.huawei.apm.backend.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Result {
+
+    private String errorCode;
+
+    private String errorMsg;
+
+    private String hint;
+
+    /**
+     * 业务ID，实际情况可能会变动
+     */
+    private Long businessId;
+}

--- a/javamesh-backend/src/main/java/com/huawei/apm/backend/server/HttpServer.java
+++ b/javamesh-backend/src/main/java/com/huawei/apm/backend/server/HttpServer.java
@@ -1,0 +1,73 @@
+package com.huawei.apm.backend.server;
+
+import com.alibaba.fastjson.JSONObject;
+import com.huawei.apm.backend.entity.*;
+import com.huawei.apm.backend.util.RandomUtil;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.*;
+
+@RestController
+@RequestMapping("/apm2")
+public class HttpServer {
+
+    RandomUtil RANDOM_UTIL = new RandomUtil();
+    private final Integer MIN = 1;
+    private final Integer MAX = 10;
+
+    private final Long random_long = RANDOM_UTIL.getRandomLong(MIN, MAX);
+    private final Integer random_int = RANDOM_UTIL.getRandomInt(MAX);
+    private final String random_str = RANDOM_UTIL.getRandomStr(MAX);
+
+
+    @PostMapping("/master/v1/register")
+    public String invokePost(@RequestBody JSONObject jsonParam) {
+        RegisterResult registerResult = new RegisterResult();
+        registerResult.setAppId(random_long);
+        registerResult.setEnvId(random_long);
+        registerResult.setDomainId(random_int);
+        registerResult.setAgentVersion(random_str);
+        registerResult.setInstanceId(random_long);
+        registerResult.setBusinessId(random_long);
+        return JSONObject.toJSONString(registerResult);
+    }
+
+    @PostMapping("/master/v1/heartbeat")
+    public String invokePost() {
+
+        Hashtable<String, String> map = new Hashtable<>();
+
+        HeartBeatResult heartBeatResult = new HeartBeatResult();
+        heartBeatResult.setHeartBeatInterval(random_int);
+        heartBeatResult.setAttachment(map);
+        heartBeatResult.setMonitorItemList(Collections.singletonList(getMonitorItem(map)));
+        heartBeatResult.setSystemProperties(map);
+        heartBeatResult.setAccessAddressList(Collections.singletonList(getAddress()));
+        heartBeatResult.setInstanceStatus(random_int);
+        heartBeatResult.setBusinessId(random_long);
+        heartBeatResult.setMd5(random_str);
+        return JSONObject.toJSONString(heartBeatResult);
+    }
+
+    public MonitorItem getMonitorItem(Hashtable<String, String> map) {
+        MonitorItem monitorItem = new MonitorItem();
+        monitorItem.setCollectorName(random_str);
+        monitorItem.setInterval(random_int);
+        monitorItem.setCollectorId(random_int);
+        monitorItem.setMonitorItemId(random_long);
+        monitorItem.setStatus(random_int);
+        monitorItem.setParameters(map);
+        return monitorItem;
+    }
+
+    public Address getAddress() {
+        Address address = new Address();
+        address.setHost(random_str);
+        address.setPort(random_int);
+        address.setSport(random_int);
+        address.setType(AddressType.access);
+        address.setScope(AddressScope.outer);
+        address.setProtocol(Protocol.WS);
+        return address;
+    }
+}

--- a/javamesh-backend/src/main/java/com/huawei/apm/backend/server/ServerHandler.java
+++ b/javamesh-backend/src/main/java/com/huawei/apm/backend/server/ServerHandler.java
@@ -83,6 +83,12 @@ public class ServerHandler extends BaseHandler {
                 case Message.ServiceData.DataType.AGENT_REGISTRATION_VALUE:
                     producer.send(new ProducerRecord<>(conf.getTopicAgentRegistration(), Bytes.wrap(message)));
                     break;
+                case Message.ServiceData.DataType.AGENT_MONITOR_VALUE:
+                    producer.send(new ProducerRecord<>(conf.getTopicAgentMonitor(), Bytes.wrap(message)));
+                    break;
+                case Message.ServiceData.DataType.AGENT_SPAN_EVENT_VALUE:
+                    producer.send(new ProducerRecord<>(conf.getTopicAgentSpanEvent(), Bytes.wrap(message)));
+                    break;
                 default:
                     break;
             }

--- a/javamesh-backend/src/main/java/com/huawei/apm/backend/util/RandomUtil.java
+++ b/javamesh-backend/src/main/java/com/huawei/apm/backend/util/RandomUtil.java
@@ -1,0 +1,21 @@
+package com.huawei.apm.backend.util;
+
+import org.apache.commons.lang.RandomStringUtils;
+
+import java.util.Random;
+
+public class RandomUtil {
+
+    public Integer getRandomInt(Integer range) {
+        Random rand = new Random();
+        return rand.nextInt(range) + 1;
+    }
+
+    public String getRandomStr(Integer len) {
+        return RandomStringUtils.randomAlphanumeric(len);
+    }
+
+    public Long getRandomLong(Integer min, Integer max) {
+        return min + (((long) (new Random().nextDouble() * (max - min))));
+    }
+}

--- a/javamesh-backend/src/main/proto/Message.proto
+++ b/javamesh-backend/src/main/proto/Message.proto
@@ -28,6 +28,8 @@ message ServiceData{
     ORACLE_JVM_MONITOR = 5;
     IBM_JVM_MONITOR = 6;
     AGENT_REGISTRATION = 7;
+    AGENT_MONITOR = 8;
+    AGENT_SPAN_EVENT = 9;
   }
   DataType dataType = 1;
   bytes data = 2;

--- a/javamesh-backend/src/main/resources/application.properties
+++ b/javamesh-backend/src/main/resources/application.properties
@@ -7,6 +7,8 @@ kafka.server-monitor.topic=topic-server-monitor
 kafka.oracle-jvm-monitor.topic=topic-oracle-jvm-monitor
 kafka.ibm-jvm-monitor.topic=topic-ibm-jvm-monitor
 kafka.agent-registration.topic=topic-agent-registration
+kafka.agent-monitor.topic=topic-agent-monitor
+kafka.agent-span-event.topic=topic-agent-span-event
 # netty config
 netty.port=6888
 netty.wait.time=60

--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,7 @@
             <modules>
                 <module>javamesh-agentcore</module>
                 <module>javamesh-samples</module>
+                <module>javamesh-backend</module>
             </modules>
         </profile>
         <profile>


### PR DESCRIPTION
【issue号】#120

【修改原因】

1. 框架启动后luban注册，数据发送等功能连不上服务器报错

【修改内容】

1. backend模块实现luban注册和心跳接口，在框架启动之后模拟luban后端接受注册和心跳的请求。
2. luban监控和链路数据发送由websocket发送改为统一消息模块发送，原luban逻辑暂时保留，
3. boostrap配置文件服务器地址端口修改
4. example打包中加入backend模块

【检查者】@fuziye01 @HapThorin

【用例描述】暂无

【自测情况】本地测试通过

【影响范围】

1. backend模块添加了两个http请求接口
2. luban监控和链路数据通过统一消息模块发往backend，写入kafka