### PR TITLE
core心跳添加版本字段，查询插件信息接口修改

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,9 +2,6 @@ name: Java CI with Maven
 
 on:
   push:
-    branches:
-      - master
-      - develop
   pull_request:
     branches:
       - master

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/transfer/dto/heartbeat/HeartbeatMessage.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/transfer/dto/heartbeat/HeartbeatMessage.java
@@ -2,6 +2,7 @@ package com.huawei.javamesh.core.lubanops.core.transfer.dto.heartbeat;
 
 import com.alibaba.fastjson.JSONException;
 import com.alibaba.fastjson.JSONObject;
+import com.huawei.javamesh.core.common.BootArgsIndexer;
 import com.huawei.javamesh.core.lubanops.bootstrap.config.IdentityConfigManager;
 import com.huawei.javamesh.core.lubanops.bootstrap.log.LogFactory;
 import com.huawei.javamesh.core.lubanops.core.utils.NetworkUtil;
@@ -25,6 +26,7 @@ public class HeartbeatMessage {
         message.put("appType", IdentityConfigManager.getAppType());
         message.put("heartbeatVersion", String.valueOf(TimeUtil.currentTimeMillis()));
         message.put("lastHeartbeat", String.valueOf(TimeUtil.currentTimeMillis()));
+        message.put("version", BootArgsIndexer.getCoreVersion());
     }
 
     public HeartbeatMessage registerInformation(String key, String value) {

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/heartbeat/HeartbeatService.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/heartbeat/HeartbeatService.java
@@ -14,10 +14,6 @@ import com.huawei.javamesh.core.service.BaseService;
  * @since 2021/10/25
  */
 public interface HeartbeatService extends BaseService {
-    /**
-     * 心跳的版本键
-     */
-    String VERSION_KEY = "version";
 
     /**
      * 心跳的插件名称键

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/heartbeat/HeartbeatServiceImpl.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/heartbeat/HeartbeatServiceImpl.java
@@ -131,7 +131,6 @@ public class HeartbeatServiceImpl implements HeartbeatService {
      */
     private void heartbeat(NettyClient nettyClient, String pluginName, String pluginVersion) {
         final HeartbeatMessage message = new HeartbeatMessage()
-                .registerInformation(VERSION_KEY, BootArgsIndexer.getCoreVersion())
                 .registerInformation(PLUGIN_NAME_KEY, pluginName)
                 .registerInformation(PLUGIN_VERSION_KEY, pluginVersion);
         addExtInfo(pluginName, message);

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/AgentInfo.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/AgentInfo.java
@@ -3,6 +3,8 @@ package com.huawei.javamesh.backend.entity;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.List;
+
 @Getter
 @Setter
 public class AgentInfo {
@@ -11,7 +13,9 @@ public class AgentInfo {
 
     private Object version;
 
+    private Object lastHeartbeatTime;
+
     private Object heartbeatTime;
 
-    private String pluginsInfo;
+    private List<PluginInfo> pluginsInfos;
 }

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/PluginInfo.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/PluginInfo.java
@@ -1,0 +1,12 @@
+package com.huawei.javamesh.backend.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PluginInfo {
+    String name;
+
+    String version;
+}


### PR DESCRIPTION
【issue号/问题单号/需求单号】#154

【修改原因】

原因一：core模块心跳没有版本信息
原因二：插件心跳信息增加了版本字段，需要对查询插件信息接口做调整
原因三：develop和master以外的分支推动代码不会触发门禁

【修改内容】

增加了core模块心跳版本字段；
增加了录制插件名称和版本字段；
修改了backend查询插件信息的接口。
修改了门禁触发条件。

【检查者】@fuziye01 @HapThorin 

【用例描述】暂无用例

【自测情况】

1. 本地测试通过。
2. 本地启动zk, kafka，通过postman调用查询接口，正确返回插件信息。

【影响范围】

1. 框架心跳增加版本字段
2. 录制插件增加名称和版本字段