### PR TITLE
【新功能】流控模块中类的头信息整改

### DIFF
--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/AlibabaDubboDefinition.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/AlibabaDubboDefinition.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/AlibabaDubboInterceptor.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/AlibabaDubboInterceptor.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/ApacheDubboDefinition.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/ApacheDubboDefinition.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/ApacheDubboInterceptor.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/ApacheDubboInterceptor.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/DispatcherServletDefinition.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/DispatcherServletDefinition.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/DispatcherServletInterceptor.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/DispatcherServletInterceptor.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/DubboDefinition.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/DubboDefinition.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.huawei.flowcontrol;
 
 import com.huawei.javamesh.core.agent.definition.EnhanceDefinition;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/DubboInterceptor.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/DubboInterceptor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.huawei.flowcontrol;
 
 import com.alibaba.csp.sentinel.log.RecordLog;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/ResolverManager.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/ResolverManager.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/RuleSyncer.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/RuleSyncer.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/constants/CseConstants.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/constants/CseConstants.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.constants;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/converter/Converter.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/converter/Converter.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.converter;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/converter/YamlConverter.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/converter/YamlConverter.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.converter;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/datasource/CseDataSourceManager.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/datasource/CseDataSourceManager.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.datasource;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/datasource/CseKieDataSource.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/datasource/CseKieDataSource.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.datasource;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/enhancer/KieConfigurationEnhancer.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/enhancer/KieConfigurationEnhancer.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.enhancer;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/enhancer/ServiceCombServiceMetaEnhancer.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/enhancer/ServiceCombServiceMetaEnhancer.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.enhancer;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/entity/CseMatchRequest.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/entity/CseMatchRequest.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.entity;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/entity/CseServiceMeta.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/entity/CseServiceMeta.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.entity;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/interceptors/KieConfigurationInterceptor.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/interceptors/KieConfigurationInterceptor.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.interceptors;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/interceptors/MetricServiceMetaInterceptor.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/interceptors/MetricServiceMetaInterceptor.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.interceptors;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/BusinessMatcher.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/BusinessMatcher.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.match;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/MatchGroupResolver.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/MatchGroupResolver.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.match;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/MatchManager.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/MatchManager.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.match;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/Matcher.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/Matcher.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.match;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/RawOperator.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/RawOperator.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.match;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/RequestMatcher.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/RequestMatcher.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.match;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/operator/CompareOperator.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/operator/CompareOperator.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.match.operator;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/operator/ContainOperator.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/operator/ContainOperator.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.match.operator;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/operator/ExactOperator.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/operator/ExactOperator.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.match.operator;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/operator/Operator.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/operator/Operator.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.match.operator;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/operator/OperatorManager.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/operator/OperatorManager.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.match.operator;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/operator/PrefixOperator.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/operator/PrefixOperator.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.match.operator;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/operator/SuffixOperator.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/operator/SuffixOperator.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.match.operator;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/AbstractResolver.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/AbstractResolver.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.resolver;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/AbstractRuleResolver.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/AbstractRuleResolver.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.resolver;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/BulkThreadRuleResolver.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/BulkThreadRuleResolver.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.resolver;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/CircuitBreakerRuleResolver.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/CircuitBreakerRuleResolver.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.resolver;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/RateLimitingRuleResolver.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/RateLimitingRuleResolver.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.resolver;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/Resolver.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/Resolver.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.resolver;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/RetryResolver.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/RetryResolver.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.resolver;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/listener/ConfigUpdateListener.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/listener/ConfigUpdateListener.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.resolver.listener;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/AbstractRule.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/AbstractRule.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.rule;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/BulkThreadRule.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/BulkThreadRule.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.rule;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/CircuitBreakerRule.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/CircuitBreakerRule.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.rule;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/Configurable.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/Configurable.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.rule;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/RateLimitingRule.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/RateLimitingRule.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.rule;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/RetryRule.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/RetryRule.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.rule;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/Rule.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/Rule.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.rule;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/config/CommonConst.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/config/CommonConst.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.config;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/FlowControlThreadFactory.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/FlowControlThreadFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.huawei.flowcontrol.core;
 
 import java.util.concurrent.ThreadFactory;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/config/CommonConst.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/config/CommonConst.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.config;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/config/ConfigConst.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/config/ConfigConst.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.config;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/config/FlowControlConfig.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/config/FlowControlConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.huawei.flowcontrol.core.config;
 
 import com.huawei.javamesh.core.config.common.ConfigTypeKey;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/config/KafkaConnectBySslSwitch.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/config/KafkaConnectBySslSwitch.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.huawei.flowcontrol.core.config;
 
 import com.huawei.javamesh.core.plugin.config.PluginConfigManager;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/config/KafkaConst.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/config/KafkaConst.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.config;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/DataSourceManager.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/DataSourceManager.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.datasource;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/DataSourceUpdateSupport.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/DataSourceUpdateSupport.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.datasource;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/DefaultDataSource.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/DefaultDataSource.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.datasource;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/DefaultDataSourceManager.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/DefaultDataSourceManager.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.datasource;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/KieAutoRefreshDataSource.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/KieAutoRefreshDataSource.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.datasource.kie;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/RuleCenter.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/RuleCenter.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.datasource.kie.rule;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/RuleWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/RuleWrapper.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.datasource.kie.rule;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/authority/AuthorityRuleWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/authority/AuthorityRuleWrapper.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.datasource.kie.rule.authority;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/degrade/DegradeRuleWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/degrade/DegradeRuleWrapper.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.datasource.kie.rule.degrade;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/flow/FlowRuleWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/flow/FlowRuleWrapper.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.datasource.kie.rule.flow;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/system/SystemRuleWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/system/SystemRuleWrapper.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.datasource.kie.rule.system;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/util/KieConfigClient.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/util/KieConfigClient.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.datasource.kie.util;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/util/response/KieConfigItem.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/util/response/KieConfigItem.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.datasource.kie.util.response;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/util/response/KieConfigLabels.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/util/response/KieConfigLabels.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.datasource.kie.util.response;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/util/response/KieConfigResponse.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/util/response/KieConfigResponse.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.datasource.kie.util.response;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/zookeeper/ZookeeperCoreDataSource.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/zookeeper/ZookeeperCoreDataSource.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.datasource.zookeeper;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/zookeeper/ZookeeperDatasourceManager.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/zookeeper/ZookeeperDatasourceManager.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.datasource.zookeeper;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/heartbeat/HeartbeatMessage.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/heartbeat/HeartbeatMessage.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.heartbeat;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/heartbeat/KafkaHeartbeatSender.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/heartbeat/KafkaHeartbeatSender.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.heartbeat;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/init/InitExecutor.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/init/InitExecutor.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.init;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/init/InitRuleRedis.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/init/InitRuleRedis.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.init;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/metric/MetricMessage.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/metric/MetricMessage.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.metric;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/metric/SimpleKafkaMetricSender.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/metric/SimpleKafkaMetricSender.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.metric;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/DataSourceInitUtils.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/DataSourceInitUtils.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.util;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/KafkaProducerEnum.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/KafkaProducerEnum.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.util;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/KafkaProducerUtil.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/KafkaProducerUtil.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.util;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/PluginConfigUtil.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/PluginConfigUtil.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.util;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/RedisClient.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/RedisClient.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.util;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/RedisRuleUtil.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/RedisRuleUtil.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.util;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/ZookeeperConnectionEnum.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/ZookeeperConnectionEnum.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.core.util;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/entry/EntryFacade.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/entry/EntryFacade.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.entry;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/exception/FlowControlException.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/exception/FlowControlException.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.exception;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/service/FlowControlServiceImpl.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/service/FlowControlServiceImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.huawei.flowcontrol.service;
 
 import com.huawei.javamesh.core.common.LoggerFactory;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/util/FilterUtil.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/util/FilterUtil.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.util;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/util/SentinelRuleUtil.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/util/SentinelRuleUtil.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.util;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/util/StringUtils.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/util/StringUtils.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.util;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/util/TraceEntryUtils.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/util/TraceEntryUtils.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.util;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/test/java/com/huawei/flowcontrol/adapte/cse/test/ResolverManagerTest.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/test/java/com/huawei/flowcontrol/adapte/cse/test/ResolverManagerTest.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.test;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/test/java/com/huawei/flowcontrol/adapte/cse/test/RuleResolveTest.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/test/java/com/huawei/flowcontrol/adapte/cse/test/RuleResolveTest.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.test;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/test/java/com/huawei/flowcontrol/adapte/cse/test/RuleSyncerTest.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/test/java/com/huawei/flowcontrol/adapte/cse/test/RuleSyncerTest.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.adapte.cse.test;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/DashboardApplication.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/DashboardApplication.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/config/CasConfig.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/config/CasConfig.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.config;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/config/RedisConfig.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/config/RedisConfig.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.config;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/config/RedisSessionConfiguration.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/config/RedisSessionConfiguration.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.config;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/controller/LoginController.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/controller/LoginController.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.controller;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/client/KieConfigClient.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/client/KieConfigClient.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.client;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/client/response/KieConfigItem.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/client/response/KieConfigItem.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.client.response;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/client/response/KieConfigLabel.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/client/response/KieConfigLabel.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.client.response;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/client/response/KieConfigResponse.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/client/response/KieConfigResponse.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.client.response;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/controller/KieDegradeControllerWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/controller/KieDegradeControllerWrapper.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.controller;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/controller/KieFlowControllerWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/controller/KieFlowControllerWrapper.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.controller;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/controller/KieParamFlowControllerWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/controller/KieParamFlowControllerWrapper.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.controller;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/controller/KieRuleCommonController.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/controller/KieRuleCommonController.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.controller;
 
 import com.alibaba.fastjson.JSON;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/controller/KieSystemControllerWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/controller/KieSystemControllerWrapper.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.controller;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/discovery/KieServerDiscovery.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/discovery/KieServerDiscovery.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.discovery;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/discovery/KieServerManagement.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/discovery/KieServerManagement.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.discovery;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/discovery/SimpleKieDiscovery.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/discovery/SimpleKieDiscovery.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.discovery;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/discovery/common/KieServerInfo.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/discovery/common/KieServerInfo.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.discovery.common;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/discovery/common/KieServerLabel.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/discovery/common/KieServerLabel.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.discovery.common;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/exception/KieGeneralException.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/exception/KieGeneralException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.exception;
 
 /**

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/CommonKieRuleProvider.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/CommonKieRuleProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.operator;
 
 import com.alibaba.csp.sentinel.slots.block.AbstractRule;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/CommonKieRulePublisher.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/CommonKieRulePublisher.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.operator;
 
 import com.alibaba.csp.sentinel.log.RecordLog;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/DegradeRuleCommonKiePublisher.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/DegradeRuleCommonKiePublisher.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.operator;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/DegradeRuleKieProvider.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/DegradeRuleKieProvider.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.operator;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/FlowRuleCommonKiePublisher.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/FlowRuleCommonKiePublisher.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.operator;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/FlowRuleKieProvider.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/FlowRuleKieProvider.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.operator;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/ParamFlowRuleCommonKiePublisher.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/ParamFlowRuleCommonKiePublisher.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.operator;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/ParamFlowRuleKieProvider.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/ParamFlowRuleKieProvider.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.operator;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/RuleKieProvider.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/RuleKieProvider.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.operator;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/RuleKiePublisher.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/RuleKiePublisher.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.operator;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/SystemRuleCommonKiePublisher.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/SystemRuleCommonKiePublisher.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.operator;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/SystemRuleKieProvider.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/SystemRuleKieProvider.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.operator;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/util/KieConfig.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/util/KieConfig.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.util;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/util/KieConfigUtil.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/util/KieConfigUtil.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.kie.util;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/wrapper/DegradeControllerWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/wrapper/DegradeControllerWrapper.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.wrapper;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/wrapper/FlowControllerWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/wrapper/FlowControllerWrapper.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.wrapper;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/wrapper/ParamFlowControllerWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/wrapper/ParamFlowControllerWrapper.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.wrapper;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/wrapper/SystemControllerWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/wrapper/SystemControllerWrapper.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.wrapper;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/RuleZookeeperProvider.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/RuleZookeeperProvider.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.zookeeper;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/RuleZookeeperPublisher.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/RuleZookeeperPublisher.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.zookeeper;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/ZookeeperConfig.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/ZookeeperConfig.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.zookeeper;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/ZookeeperConfigUtil.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/ZookeeperConfigUtil.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.zookeeper;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/controller/ZookeeperDegradeControllerWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/controller/ZookeeperDegradeControllerWrapper.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.zookeeper.controller;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/controller/ZookeeperFlowControllerWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/controller/ZookeeperFlowControllerWrapper.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.zookeeper.controller;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/controller/ZookeeperParamFlowRuleControllerWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/controller/ZookeeperParamFlowRuleControllerWrapper.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.zookeeper.controller;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/controller/ZookeeperSystemControllerWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/controller/ZookeeperSystemControllerWrapper.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.datasource.entity.rule.zookeeper.controller;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/discovery/RedisMachineDiscovery.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/discovery/RedisMachineDiscovery.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.discovery;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/filter/LoginFilter.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/filter/LoginFilter.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.filter;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/filter/SafeHttpServletRequestWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/filter/SafeHttpServletRequestWrapper.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.filter;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/rule/DynamicRuleProviderExt.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/rule/DynamicRuleProviderExt.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.rule;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/rule/DynamicRulePublisherExt.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/rule/DynamicRulePublisherExt.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.rule;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/util/DataType.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/util/DataType.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2020. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.util;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/util/Md5Util.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/util/Md5Util.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2020. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.util;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/util/RedisUtil.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/util/RedisUtil.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.util;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/util/SystemUtils.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/util/SystemUtils.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowcontrol.console.util;


### PR DESCRIPTION
【issue号】#167

【修改原因】项目自研源码头信息整改

【修改内容】修改流控插件与流控后台的license头

【检查者】@fuziye01 @HapThorin  @xuezechao-hub @beetle-man

【用例描述】不涉及

【自测情况】本地测试通过
