### PR TITLE
【新功能】灰度发布模块中类的头信息整改

### DIFF
--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/AbstractInstDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/AbstractInstDefinition.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.definition;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/apache/ClusterDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/apache/ClusterDefinition.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.definition.apache;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/apache/DubboInvokerDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/apache/DubboInvokerDefinition.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.definition.apache;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/apache/InterfaceConfigDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/apache/InterfaceConfigDefinition.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.definition.apache;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/apache/MonitorFilterDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/apache/MonitorFilterDefinition.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.definition.apache;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/apache/RegistryDirectoryDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/apache/RegistryDirectoryDefinition.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.definition.apache;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/servicecomb/RegistrationDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/servicecomb/RegistrationDefinition.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.definition.servicecomb;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/interceptor/apache/ClusterInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/interceptor/apache/ClusterInterceptor.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.interceptor.apache;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/interceptor/apache/DubboInvokerInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/interceptor/apache/DubboInvokerInterceptor.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.interceptor.apache;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/interceptor/apache/InterfaceConfigInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/interceptor/apache/InterfaceConfigInterceptor.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.interceptor.apache;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/interceptor/apache/MonitorFilterInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/interceptor/apache/MonitorFilterInterceptor.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.interceptor.apache;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/interceptor/apache/RegistryDirectoryInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/interceptor/apache/RegistryDirectoryInterceptor.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.interceptor.apache;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/interceptor/servicecomb/RegistrationInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/interceptor/servicecomb/RegistrationInterceptor.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.interceptor.servicecomb;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/service/AbstractPluginService.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/service/AbstractPluginService.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.service;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/service/DubboInvokerService.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/service/DubboInvokerService.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.service;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/service/InterfaceConfigService.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/service/InterfaceConfigService.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.service;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/service/MonitorFilterService.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/service/MonitorFilterService.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.service;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/service/RegistrationService.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/service/RegistrationService.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.service;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/service/RegistryDirectoryService.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/service/RegistryDirectoryService.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.service;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/cache/DubboCache.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/cache/DubboCache.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.cache;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/service/ConfigServiceImpl.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/service/ConfigServiceImpl.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.service;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/service/DubboInvokerServiceImpl.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/service/DubboInvokerServiceImpl.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.service;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/service/InterfaceConfigServiceImpl.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/service/InterfaceConfigServiceImpl.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.service;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/service/MonitorFilterServiceImpl.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/service/MonitorFilterServiceImpl.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.service;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/service/RegistrationServiceImpl.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/service/RegistrationServiceImpl.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.service;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/service/RegistryDirectoryServiceImpl.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/service/RegistryDirectoryServiceImpl.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.service;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/RuleStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/RuleStrategy.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.strategy;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/RuleStrategyEnum.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/RuleStrategyEnum.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.strategy;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/TypeStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/TypeStrategy.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.strategy;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/TypeStrategyChooser.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/TypeStrategyChooser.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.strategy;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/rule/UpstreamRuleStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/rule/UpstreamRuleStrategy.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.strategy.rule;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/rule/WeightRuleStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/rule/WeightRuleStrategy.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.strategy.rule;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/type/ArrayTypeStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/type/ArrayTypeStrategy.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.strategy.type;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/type/EmptyTypeStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/type/EmptyTypeStrategy.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.strategy.type;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/type/EnabledTypeStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/type/EnabledTypeStrategy.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.strategy.type;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/type/ListTypeStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/type/ListTypeStrategy.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.strategy.type;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/type/MapTypeStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/type/MapTypeStrategy.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.strategy.type;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/type/ObjectTypeStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/type/ObjectTypeStrategy.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.strategy.type;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/utils/RouterUtil.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/utils/RouterUtil.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.dubbo.utils;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/HttpClientDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/HttpClientDefinition.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.feign.definition;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/LoadBalancerFeignClientDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/LoadBalancerFeignClientDefinition.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.feign.definition;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/register/EurekaClientRegisterDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/register/EurekaClientRegisterDefinition.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.feign.definition.register;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/register/NacosRegisterDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/register/NacosRegisterDefinition.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.feign.definition.register;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/register/ServiceCenterRegisterDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/register/ServiceCenterRegisterDefinition.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.feign.definition.register;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/register/ServiceCombRegisterDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/register/ServiceCombRegisterDefinition.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.feign.definition.register;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/register/ZookeeperRegisterDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/register/ZookeeperRegisterDefinition.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.feign.definition.register;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/EurekaClientRegisterInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/EurekaClientRegisterInterceptor.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.feign.interceptor;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/LoadBalancerClientInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/LoadBalancerClientInterceptor.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.feign.interceptor;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/NacosRegisterInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/NacosRegisterInterceptor.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.feign.interceptor;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/ServiceCenterRegisterInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/ServiceCenterRegisterInterceptor.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.feign.interceptor;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/ServiceCombRegisterInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/ServiceCombRegisterInterceptor.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.feign.interceptor;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/ZookeeperRegisterInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/ZookeeperRegisterInterceptor.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.feign.interceptor;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/service/LoadBalancerClientService.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/service/LoadBalancerClientService.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.feign.service;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/service/RegisterService.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/service/RegisterService.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.feign.service;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/context/CurrentInstance.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/context/CurrentInstance.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.feign.context;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/context/HostContext.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/context/HostContext.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.feign.context;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/rule/RuleStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/rule/RuleStrategy.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.feign.rule;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/rule/RuleType.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/rule/RuleType.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.feign.rule;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/rule/UpstreamRuleStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/rule/UpstreamRuleStrategy.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.feign.rule;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/rule/WeightRuleStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/rule/WeightRuleStrategy.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.feign.rule;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/service/LoadBalancerClientServiceImpl.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/service/LoadBalancerClientServiceImpl.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.feign.service;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/service/RegisterServiceImpl.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/service/RegisterServiceImpl.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.feign.service;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/util/RouterUtil.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/util/RouterUtil.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.gray.feign.util;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/factory/NamedThreadFactory.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/factory/NamedThreadFactory.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.factory;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/addr/AddrCache.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/addr/AddrCache.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.addr;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/addr/entity/Addr.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/addr/entity/Addr.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.addr.entity;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/addr/entity/Instances.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/addr/entity/Instances.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.addr.entity;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/addr/entity/Metadata.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/addr/entity/Metadata.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.addr.entity;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/config/GrayConfig.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/config/GrayConfig.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.config;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/constants/GrayConstant.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/constants/GrayConstant.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.huawei.route.common.gray.constants;
 
 /**

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/LabelCache.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/LabelCache.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.label;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/CurrentTag.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/CurrentTag.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.label.entity;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/GrayConfiguration.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/GrayConfiguration.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.label.entity;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/Match.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/Match.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.label.entity;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/MatchRule.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/MatchRule.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.label.entity;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/MatchStrategy.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/MatchStrategy.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.label.entity;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/Route.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/Route.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.label.entity;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/Rule.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/Rule.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.label.entity;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/Tags.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/Tags.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.label.entity;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/ValueMatch.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/ValueMatch.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.label.entity;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/ValueMatchDeserializer.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/ValueMatchDeserializer.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.label.entity;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/VersionFrom.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/VersionFrom.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.label.entity;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/listener/GrayConfigListener.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/listener/GrayConfigListener.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.listener;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/ValueMatchStrategy.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/ValueMatchStrategy.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.strategy;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/ExactValueMatchStrategy.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/ExactValueMatchStrategy.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.strategy.match;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/GreaterValueMatchStrategy.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/GreaterValueMatchStrategy.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.strategy.match;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/InValueMatchStrategy.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/InValueMatchStrategy.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.strategy.match;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/LessValueMatchStrategy.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/LessValueMatchStrategy.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.strategy.match;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/NoEquValueMatchStrategy.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/NoEquValueMatchStrategy.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.strategy.match;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/NoGreaterValueMatchStrategy.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/NoGreaterValueMatchStrategy.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.strategy.match;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/NoLessValueMatchStrategy.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/NoLessValueMatchStrategy.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.strategy.match;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/PrefixValueMatchStrategy.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/PrefixValueMatchStrategy.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.strategy.match;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/RegexValueMatchStrategy.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/RegexValueMatchStrategy.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.gray.strategy.match;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/threadlocal/ThreadLocalContext.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/threadlocal/ThreadLocalContext.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.threadlocal;

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/utils/CollectionUtils.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/utils/CollectionUtils.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.route.common.utils;


### PR DESCRIPTION
【issue号】#167

【修改原因】项目自研源码头信息整改

【修改内容】修改灰度发布模块的license头

【检查者】@fuziye01 @HapThorin @xuezechao-hub @beetle-man 
【用例描述】不涉及

【自测情况】本地测试通过