### PR TITLE
为feign灰度发布模块中使用或修改SkyWalking源码的类添加Apache Software Foundation (ASF)头信息

### DIFF
--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/DefaultHttpClientDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/DefaultHttpClientDefinition.java
@@ -1,5 +1,19 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  */
 
 package com.huawei.gray.feign.definition;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/PathVarDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/PathVarDefinition.java
@@ -1,5 +1,19 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  */
 
 package com.huawei.gray.feign.definition;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/DefaultHttpClientInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/DefaultHttpClientInterceptor.java
@@ -1,5 +1,19 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  */
 
 package com.huawei.gray.feign.interceptor;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/PathVarInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/PathVarInterceptor.java
@@ -1,5 +1,19 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  */
 
 package com.huawei.gray.feign.interceptor;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/service/DefaultHttpClientService.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/service/DefaultHttpClientService.java
@@ -1,5 +1,19 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  */
 
 package com.huawei.gray.feign.service;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/service/PathVarService.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/service/PathVarService.java
@@ -1,5 +1,19 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  */
 
 package com.huawei.gray.feign.service;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/context/FeignResolvedURL.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/context/FeignResolvedURL.java
@@ -1,5 +1,19 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  */
 
 package com.huawei.gray.feign.context;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/service/DefaultHttpClientServiceImpl.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/service/DefaultHttpClientServiceImpl.java
@@ -1,5 +1,19 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  */
 
 package com.huawei.gray.feign.service;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/service/PathVarServiceImpl.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/service/PathVarServiceImpl.java
@@ -1,5 +1,19 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  */
 
 package com.huawei.gray.feign.service;


### PR DESCRIPTION
【issue号/问题单号/需求单号】

【修改原因】

原因： 开发过程中获取feign请求的url参考了skywalking，并在更改灰度应用请求ip的代码中使用到了feign请求的url，需要添加ASF copyright。

【修改内容】

增加了ASF copyright

【检查者】@yangyshdan @HapThorin @fuziye01

【用例描述】不需要测试用例

【自测情况】本地测试通过

【影响范围】无影响