### PR TITLE
为流量录制模块中使用或修改skywalking源码的类添加Apache Software Foundation (ASF)头信息

### DIFF
--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/dubbo/AliDubboInterceptor.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/dubbo/AliDubboInterceptor.java
@@ -1,5 +1,18 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.huawei.flowrecord.plugins.dubbo;

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/dubbo/DubboInterceptor.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/dubbo/DubboInterceptor.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.huawei.flowrecord.plugins.dubbo;
 
 import com.huawei.javamesh.core.lubanops.bootstrap.TransformAccess;


### PR DESCRIPTION
【issue号/问题单号/需求单号】

【修改原因】原因一：未添加ASF

【修改内容】增加了ASF

【检查者】@yangyshdan @HapThorin @fuziye01 

【用例描述】无需测试用例

【自测情况】未修改代码

【影响范围】无