### PR TITLE
为核心模块和监控插件模块中使用或修改skywalking源码的类添加Apache Software Foundation (ASF)头信息

### DIFF
--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/AnnotationMatcher.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/AnnotationMatcher.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.huawei.javamesh.core.agent.matcher;
 
 import com.huawei.javamesh.core.util.Assert;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/ClassMatcher.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/ClassMatcher.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.huawei.javamesh.core.agent.matcher;
 
 /**

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/MultiClassMatcher.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/MultiClassMatcher.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.huawei.javamesh.core.agent.matcher;
 
 import com.huawei.javamesh.core.util.Assert;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/NameMatcher.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/NameMatcher.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.huawei.javamesh.core.agent.matcher;
 
 /**

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/NonNameMatcher.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/NonNameMatcher.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.huawei.javamesh.core.agent.matcher;
 
 import net.bytebuddy.description.type.TypeDescription;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/PrefixMatcher.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/PrefixMatcher.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.huawei.javamesh.core.agent.matcher;
 
 import com.huawei.javamesh.core.util.Assert;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/SuperTypeMatcher.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/SuperTypeMatcher.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package com.huawei.javamesh.core.agent.matcher;
 
 import com.huawei.javamesh.core.util.Assert;

--- a/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/provider/OpenJvmMetricProvider.java
+++ b/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/provider/OpenJvmMetricProvider.java
@@ -1,5 +1,19 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  */
 
 package com.huawei.javamesh.sample.servermonitor.provider;


### PR DESCRIPTION

【修改原因】ASF版权信息补充

【修改内容】ASF版权信息补充

【检查者】@fuziye01 @HapThorin @xuezechao-hub @justforstudy-A

【用例描述】不涉及

【自测情况】不涉及

【影响范围】无