### PR TITLE
Fix license issue for Apache Skywalking. 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -204,41 +204,101 @@
 
 The following files contain a portion of Apache Skywalking project.
 
-com/huawei/gray/feign/definition/DefaultHttpClientDefinition.java in this product is copied from org/apache/skywalking/apm/plugin/feign/http/v9/define/DefaultHttpClientInstrumentation.java of Apache SkyWalking project.
+com/huawei/javamesh/core/agent/common/BeforeResult.java in this product is copied from org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/MethodInterceptResult.java of Apache SkyWalking project.
 
-com/huawei/gray/feign/definition/PathVarDefinition.java in this product is copied from org/apache/skywalking/apm/plugin/feign/http/v9/define/PathVarInstrumentation.java of Apache SkyWalking project.
+com/huawei/javamesh/core/agent/common/OverrideArgumentsCall.java in this product is copied from org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/OverrideCallable.java of Apache SkyWalking project.
 
-com/huawei/gray/feign/interceptor/DefaultHttpClientInterceptor.java,
-com/huawei/gray/feign/service/DefaultHttpClientService.java,
-com/huawei/gray/feign/service/DefaultHttpClientServiceImpl.java
-in this product is copied from org/apache/skywalking/apm/plugin/feign/http/v9/DefaultHttpClientInterceptor.java of Apache SkyWalking project.
+com/huawei/javamesh/core/agent/definition/EnhanceDefinition.java in this product is copied from org/apache/skywalking/apm/agent/core/plugin/AbstractClassEnhancePluginDefine.java of Apache SkyWalking project.
 
-com/huawei/gray/feign/interceptor/PathVarInterceptor.java,
-com/huawei/gray/feign/service/PathVarService.java,
-com/huawei/gray/feign/service/PathVarServiceImpl.java
-in this product is copied from org/apache/skywalking/apm/plugin/feign/http/v9/PathVarInterceptor.java of Apache SkyWalking project.
+com/huawei/javamesh/core/agent/definition/MethodInterceptPoint.java in this product is copied from org/apache/skywalking/apm/agent/core/plugin/interceptor/InstanceMethodsInterceptPoint.java, org/apache/skywalking/apm/agent/core/plugin/interceptor/StaticMethodsInterceptPoint.java and org/apache/skywalking/apm/agent/core/plugin/interceptor/ConstructorInterceptPoint.java of Apache SkyWalking project.
 
-com/huawei/gray/feign/context/FeignResolvedURL.java in this product is copied from org/apache/skywalking/apm/plugin/feign/http/v9/FeignResolvedURL.java of Apache SkyWalking project.
+com/huawei/javamesh/core/agent/enhancer/AbstractAroundEnhancer.java in this product is copied from org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/InstMethodsInter.java, org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/InstMethodsInterWithOverrideArgs.java, org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/StaticMethodsInter.java and org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/StaticMethodsInterWithOverrideArgs.java of Apache SkyWalking project.
 
-com/huawei/flowrecord/plugins/dubbo/AliDubboInterceptor.java in this product is copied from org/apache/skywalking/apm/plugin/dubbo/DubboInterceptor.java of Apache SkyWalking project.
+com/huawei/javamesh/core/agent/enhancer/ConstructorEnhancer.java in this product is copied from org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/ConstructorInter.java of Apache SkyWalking project.
 
-com/huawei/flowrecord/plugins/dubbo/DubboInterceptor.java in this product is copied from org/apache/skywalking/apm/plugin/dubbo/DubboInterceptor.java of Apache SkyWalking project.
+com/huawei/javamesh/core/agent/enhancer/InstanceMethodEnhancer.java in this product is copied from org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/InstMethodsInter.java and org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/InstMethodsInterWithOverrideArgs.java of Apache SkyWalking project.
 
-com/huawei/javamesh/sample/servermonitor/provider/OpenJvmMetricProvider.java in this product is copied from org/apache/skywalking/apm/agent/core/jvm/JVMService.java of Apache SkyWalking project.
+com/huawei/javamesh/core/agent/enhancer/OriginEnhancer.java in this product is copied from org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/InstMethodsInter.java, org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/InstMethodsInterWithOverrideArgs.java, org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/StaticMethodsInter.java and org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/StaticMethodsInterWithOverrideArgs.java of Apache SkyWalking project.
 
-com/huawei/javamesh/core/agent/matcher/NonNameMatcher.java in this product is copied from org/apache/skywalking/apm/agent/core/plugin/match/IndirectMatch.java of Apache SkyWalking project.
+com/huawei/javamesh/core/agent/enhancer/StaticMethodEnhancer.java in this product is copied from org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/StaticMethodsInter.java and org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/StaticMethodsInterWithOverrideArgs.java of Apache SkyWalking project.
+
+com/huawei/javamesh/core/agent/interceptor/ConstructorInterceptor.java in this product is copied from org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/InstanceConstructorInterceptor.java of Apache SkyWalking project.
+
+com/huawei/javamesh/core/agent/interceptor/InstanceMethodInterceptor.java in this product is copied from org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/InstanceMethodsAroundInterceptor.java of Apache SkyWalking project.
+
+com/huawei/javamesh/core/agent/interceptor/InterceptorLoader.java in this product is copied from org/apache/skywalking/apm/agent/core/plugin/loader/InterceptorInstanceLoader.java of Apache SkyWalking project.
+
+com/huawei/javamesh/core/agent/interceptor/StaticMethodInterceptor.java in this product is copied from org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/StaticMethodsAroundInterceptor.java of Apache SkyWalking project.
 
 com/huawei/javamesh/core/agent/matcher/AnnotationMatcher.java in this product is copied from org/apache/skywalking/apm/agent/core/plugin/match/ClassAnnotationMatch.java of Apache SkyWalking project.
 
+com/huawei/javamesh/core/agent/matcher/ClassMatcher.java in this product is copied from org/apache/skywalking/apm/agent/core/plugin/match/ClassMatch.java of Apache SkyWalking project.
+
 com/huawei/javamesh/core/agent/matcher/MultiClassMatcher.java in this product is copied from org/apache/skywalking/apm/agent/core/plugin/match/MultiClassNameMatch.java of Apache SkyWalking project.
+
+com/huawei/javamesh/core/agent/matcher/NameMatcher.java in this product is copied from org/apache/skywalking/apm/agent/core/plugin/match/NameMatch.java of Apache SkyWalking project.
+
+com/huawei/javamesh/core/agent/matcher/NonNameMatcher.java in this product is copied from org/apache/skywalking/apm/agent/core/plugin/match/IndirectMatch.java of Apache SkyWalking project.
 
 com/huawei/javamesh/core/agent/matcher/PrefixMatcher.java in this product is copied from org/apache/skywalking/apm/agent/core/plugin/match/PrefixMatch.java of Apache SkyWalking project.
 
 com/huawei/javamesh/core/agent/matcher/SuperTypeMatcher.java in this product is copied from org/apache/skywalking/apm/agent/core/plugin/match/HierarchyMatch.java of Apache SkyWalking project.
 
-com/huawei/javamesh/core/agent/matcher/NameMatcher.java in this product is copied from org/apache/skywalking/apm/agent/core/plugin/match/NameMatch.java of Apache SkyWalking project.
+com/huawei/javamesh/core/agent/transformer/DelegateTransformer.java in this product is copied from org/apache/skywalking/apm/agent/SkyWalkingAgent.java of Apache SkyWalking project.
 
-com/huawei/javamesh/core/agent/matcher/ClassMatcher.java in this product is copied from org/apache/skywalking/apm/agent/core/plugin/match/ClassMatch.java of Apache SkyWalking project.
+com/huawei/javamesh/core/agent/ByteBuddyAgentBuilder.java in this product is copied from org/apache/skywalking/apm/agent/SkyWalkingAgent.java of Apache SkyWalking project.
+
+com/huawei/javamesh/core/agent/EnhanceDefinitionLoader.java in this product is copied from org/apache/skywalking/apm/agent/core/plugin/PluginBootstrap.java and org/apache/skywalking/apm/agent/core/plugin/PluginFinder.java of Apache SkyWalking project.
+
+com/huawei/javamesh/core/agent/matcher/ClassMatchers.java in this product is copied from org/apache/skywalking/apm/agent/core/plugin/match/NameMatch.java of Apache SkyWalking project.
+
+com/huawei/javamesh/core/service/ServiceManager.java in this product is copied from org/apache/skywalking/apm/agent/core/boot/ServiceManager.java of Apache SkyWalking project.
+
+com/huawei/flowcontrol/DubboInterceptor.java in this product is copied from org/apache/skywalking/apm/plugin/asf/dubbo/DubboInterceptor.java and org/apache/skywalking/apm/plugin/dubbo/DubboInterceptor.java of Apache SkyWalking project.
+
+com/huawei/flowcontrol/DubboDefinition.java in this product is copied from org/apache/skywalking/apm/plugin/asf/dubbo/DubboInstrumentation.java and org/apache/skywalking/apm/plugin/dubbo/DubboInstrumentation.java of Apache SkyWalking project.
+
+com/huawei/javamesh/sample/servermonitor/provider/OpenJvmMetricProvider.java in this product is copied from org/apache/skywalking/apm/agent/core/jvm/JVMService.java of Apache SkyWalking project.
+
+com/huawei/gray/feign/service/PathVarServiceImpl.java in this product is copied from org/apache/skywalking/apm/plugin/feign/http/v9/PathVarInterceptor.java of Apache SkyWalking project.
+
+com/huawei/gray/feign/service/DefaultHttpClientServiceImpl.java in this product is copied from org/apache/skywalking/apm/plugin/feign/http/v9/DefaultHttpClientInterceptor.java of Apache SkyWalking project.
+
+com/huawei/gray/feign/context/FeignResolvedURL.java in this product is copied from org/apache/skywalking/apm/plugin/feign/http/v9/FeignResolvedURL.java of Apache SkyWalking project.
+
+com/huawei/gray/feign/service/PathVarService.java in this product is copied from org/apache/skywalking/apm/plugin/feign/http/v9/PathVarInterceptor.java of Apache SkyWalking project.
+
+com/huawei/gray/feign/service/DefaultHttpClientService.java in this product is copied from org/apache/skywalking/apm/plugin/feign/http/v9/DefaultHttpClientInterceptor.java of Apache SkyWalking project.
+
+com/huawei/gray/feign/interceptor/PathVarInterceptor.java in this product is copied from org/apache/skywalking/apm/plugin/feign/http/v9/PathVarInterceptor.java of Apache SkyWalking project.
+
+com/huawei/gray/feign/interceptor/DefaultHttpClientInterceptor.java in this product is copied from org/apache/skywalking/apm/plugin/feign/http/v9/DefaultHttpClientInterceptor.java of Apache SkyWalking project.
+
+com/huawei/gray/feign/definition/PathVarDefinition.java in this product is copied from org/apache/skywalking/apm/plugin/feign/http/v9/define/PathVarInstrumentation.java of Apache SkyWalking project.
+
+com/huawei/gray/feign/definition/HttpClientDefinition.java in this product is copied from com/huawei/apm/plugin/feign/http/v9/define/HttpClientInstrumentation.java of Apache SkyWalking project.
+
+com/huawei/gray/feign/definition/DefaultHttpClientDefinition.java in this product is copied from org/apache/skywalking/apm/plugin/feign/http/v9/define/DefaultHttpClientInstrumentation.java of Apache SkyWalking project.
+
+com/huawei/gray/dubbo/definition/apache/MonitorFilterDefinition.java in this product is copied from org/apache/skywalking/apm/plugin/asf/dubbo/DubboInstrumentation.java of Apache SkyWalking project.
+
+com/huawei/flowrecord/plugins/dubbo/DubboInterceptor.java in this product is copied from org/apache/skywalking/apm/plugin/asf/dubbo/DubboInterceptor.java of Apache SkyWalking project.
+
+com/huawei/flowrecord/plugins/dubbo/DubboInstrumentation.java in this product is copied from org/apache/skywalking/apm/plugin/asf/dubbo/DubboInstrumentation.java of Apache SkyWalking project.
+
+com/huawei/flowrecord/plugins/dubbo/AliDubboInterceptor.java in this product is copied from org/apache/skywalking/apm/plugin/dubbo/DubboInterceptor.java of Apache SkyWalking project.
+
+com/huawei/flowrecord/plugins/dubbo/AliDubboInstrumentation.java in this product is copied from org/apache/skywalking/apm/plugin/dubbo/DubboInstrumentation.java of Apache SkyWalking project.
+
+com/huawei/flowcontrol/ApacheDubboInterceptor.java in this product is copied from org/apache/skywalking/apm/plugin/asf/dubbo/DubboInterceptor.java of Apache SkyWalking project.
+
+com/huawei/flowcontrol/ApacheDubboDefinition.java in this product is copied from org/apache/skywalking/apm/plugin/asf/dubbo/DubboInstrumentation.java of Apache SkyWalking project.
+
+com/huawei/flowcontrol/AlibabaDubboInterceptor.java in this product is copied from org/apache/skywalking/apm/plugin/dubbo/DubboInterceptor.java of Apache SkyWalking project.
+
+com/huawei/flowcontrol/AlibabaDubboDefinition.java in this product is copied from org/apache/skywalking/apm/plugin/dubbo/DubboInstrumentation.java of Apache SkyWalking project.
+
+
 
 Apache SkyWalking project is published at https://github.com/apache/skywalking-java  
 and it's license is Apache License Version 2.0.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,15 @@
 Java-mesh
-Copyright 2021-2021
+Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
 
 This product includes software developed at
 Huawei Technologies Co., Ltd.
+
+------------------------------------------
+
+This project also includes works from Apache SkyWalking.
+
+Apache SkyWalking
+Copyright 2017-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/README.md
+++ b/README.md
@@ -94,6 +94,6 @@ Please read  [Contribute Guide](CONTRIBUTING.md) to refer how to jion the contri
 
 - [Apache/Servicecomb-java-chassis](https://github.com/apache/servicecomb-java-chassis): Java-mesh refer the service governance algorithm from Apache Servicecomb project.
 - [Apache/Servicecomb-kie](https://github.com/apache/servicecomb-kie): Java-mesh uses servicecomb-kie as the default dynamic configuration center.
-- [Apache/SkyWalking](https://skywalking.apache.org/): Part of the framework code in Java-mesh is built based on Apache Skywalking project.
+- [Apache/SkyWalking](https://skywalking.apache.org/): The plugin architecture in this project is refered to Apache Skywalking. Part of the framework code in Java-mesh is built based on Apache Skywalking project as well.
 - [Alibaba/Sentinel](https://github.com/alibaba/Sentinel): Java-mesh's flow-control plugin is built based on Alibaba Sentinel project. 
 

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/ByteBuddyAgentBuilder.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/ByteBuddyAgentBuilder.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,6 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/SkyWalkingAgent.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.javamesh.core.agent;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/EnhanceDefinitionLoader.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/EnhanceDefinitionLoader.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,6 +13,12 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/core/plugin/PluginBootstrap.java
+ * and org/apache/skywalking/apm/agent/core/plugin/PluginFinder.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.javamesh.core.agent;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/common/BeforeResult.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/common/BeforeResult.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,6 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/MethodInterceptResult.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.javamesh.core.agent.common;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/common/OverrideArgumentsCall.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/common/OverrideArgumentsCall.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,6 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/OverrideCallable.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.javamesh.core.agent.common;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/definition/EnhanceDefinition.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/definition/EnhanceDefinition.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,6 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/core/plugin/AbstractClassEnhancePluginDefine.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.javamesh.core.agent.definition;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/definition/MethodInterceptPoint.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/definition/MethodInterceptPoint.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,6 +13,13 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/core/plugin/interceptor/InstanceMethodsInterceptPoint.java,
+ * org/apache/skywalking/apm/agent/core/plugin/interceptor/StaticMethodsInterceptPoint.java
+ * and org/apache/skywalking/apm/agent/core/plugin/interceptor/ConstructorInterceptPoint.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.javamesh.core.agent.definition;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/enhancer/AbstractAroundEnhancer.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/enhancer/AbstractAroundEnhancer.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,6 +13,14 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/InstMethodsInter.java,
+ * org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/InstMethodsInterWithOverrideArgs.java,
+ * org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/StaticMethodsInter.java
+ * and org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/StaticMethodsInterWithOverrideArgs.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.javamesh.core.agent.enhancer;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/enhancer/ConstructorEnhancer.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/enhancer/ConstructorEnhancer.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,6 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/ConstructorInter.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.javamesh.core.agent.enhancer;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/enhancer/InstanceMethodEnhancer.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/enhancer/InstanceMethodEnhancer.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,6 +13,12 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/InstMethodsInter.java
+ * and org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/InstMethodsInterWithOverrideArgs.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.javamesh.core.agent.enhancer;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/enhancer/OriginEnhancer.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/enhancer/OriginEnhancer.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,6 +13,14 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/InstMethodsInter.java,
+ * org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/InstMethodsInterWithOverrideArgs.java,
+ * org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/StaticMethodsInter.java
+ * and org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/StaticMethodsInterWithOverrideArgs.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.javamesh.core.agent.enhancer;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/enhancer/StaticMethodEnhancer.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/enhancer/StaticMethodEnhancer.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,6 +13,12 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/StaticMethodsInter.java
+ * and org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/StaticMethodsInterWithOverrideArgs.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.javamesh.core.agent.enhancer;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/interceptor/ConstructorInterceptor.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/interceptor/ConstructorInterceptor.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,6 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/InstanceConstructorInterceptor.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.javamesh.core.agent.interceptor;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/interceptor/InstanceMethodInterceptor.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/interceptor/InstanceMethodInterceptor.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,6 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/InstanceMethodsAroundInterceptor.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.javamesh.core.agent.interceptor;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/interceptor/InterceptorLoader.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/interceptor/InterceptorLoader.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,6 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/core/plugin/loader/InterceptorInstanceLoader.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.javamesh.core.agent.interceptor;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/interceptor/StaticMethodInterceptor.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/interceptor/StaticMethodInterceptor.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,6 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/StaticMethodsAroundInterceptor.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.javamesh.core.agent.interceptor;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/AnnotationMatcher.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/AnnotationMatcher.java
@@ -13,7 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/core/plugin/match/ClassAnnotationMatch.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.javamesh.core.agent.matcher;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/ClassMatcher.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/ClassMatcher.java
@@ -13,7 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/core/plugin/match/ClassMatch.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.javamesh.core.agent.matcher;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/ClassMatchers.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/ClassMatchers.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/core/plugin/match/NameMatch.java
+ * from the Apache Skywalking project.
+ */
+
 package com.huawei.javamesh.core.agent.matcher;
 
 /**

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/MultiClassMatcher.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/MultiClassMatcher.java
@@ -13,7 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/core/plugin/match/MultiClassNameMatch.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.javamesh.core.agent.matcher;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/NameMatcher.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/NameMatcher.java
@@ -13,7 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/core/plugin/match/NameMatch.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.javamesh.core.agent.matcher;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/NonNameMatcher.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/NonNameMatcher.java
@@ -13,7 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/core/plugin/match/IndirectMatch.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.javamesh.core.agent.matcher;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/PrefixMatcher.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/PrefixMatcher.java
@@ -13,7 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/core/plugin/match/PrefixMatch.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.javamesh.core.agent.matcher;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/SuperTypeMatcher.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/matcher/SuperTypeMatcher.java
@@ -13,7 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/core/plugin/match/HierarchyMatch.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.javamesh.core.agent.matcher;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/transformer/DelegateTransformer.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/transformer/DelegateTransformer.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,6 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/SkyWalkingAgent.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.javamesh.core.agent.transformer;

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/ServiceManager.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/ServiceManager.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,6 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/core/boot/ServiceManager.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.javamesh.core.service;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/AlibabaDubboDefinition.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/AlibabaDubboDefinition.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,6 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/plugin/dubbo/DubboInstrumentation.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.flowcontrol;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/AlibabaDubboInterceptor.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/AlibabaDubboInterceptor.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,6 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/plugin/dubbo/DubboInterceptor.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.flowcontrol;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/ApacheDubboDefinition.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/ApacheDubboDefinition.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,6 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/plugin/asf/dubbo/DubboInstrumentation.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.flowcontrol;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/ApacheDubboInterceptor.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/ApacheDubboInterceptor.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,6 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/plugin/asf/dubbo/DubboInterceptor.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.flowcontrol;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/DubboDefinition.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/DubboDefinition.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,6 +13,12 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/plugin/asf/dubbo/DubboInstrumentation.java
+ * and org/apache/skywalking/apm/plugin/dubbo/DubboInstrumentation.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.flowcontrol;

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/DubboInterceptor.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/DubboInterceptor.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,6 +13,12 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/plugin/asf/dubbo/DubboInterceptor.java
+ * and org/apache/skywalking/apm/plugin/dubbo/DubboInterceptor.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.flowcontrol;

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/dubbo/AliDubboInstrumentation.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/dubbo/AliDubboInstrumentation.java
@@ -1,5 +1,23 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/plugin/dubbo/DubboInstrumentation.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.flowrecord.plugins.dubbo;

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/dubbo/AliDubboInterceptor.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/dubbo/AliDubboInterceptor.java
@@ -15,6 +15,11 @@
  * limitations under the License.
  */
 
+/*
+ * Based on org/apache/skywalking/apm/plugin/dubbo/DubboInterceptor.java
+ * from the Apache Skywalking project.
+ */
+
 package com.huawei.flowrecord.plugins.dubbo;
 
 import com.alibaba.dubbo.common.URL;

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/dubbo/DubboInstrumentation.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/dubbo/DubboInstrumentation.java
@@ -1,5 +1,23 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/plugin/asf/dubbo/DubboInstrumentation.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.flowrecord.plugins.dubbo;

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/dubbo/DubboInterceptor.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/dubbo/DubboInterceptor.java
@@ -15,6 +15,11 @@
  * limitations under the License.
  */
 
+/*
+ * Based on org/apache/skywalking/apm/plugin/asf/dubbo/DubboInterceptor.java
+ * from the Apache Skywalking project.
+ */
+
 package com.huawei.flowrecord.plugins.dubbo;
 
 import com.huawei.javamesh.core.lubanops.bootstrap.TransformAccess;

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/apache/MonitorFilterDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/apache/MonitorFilterDefinition.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,6 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/plugin/asf/dubbo/DubboInstrumentation.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.gray.dubbo.definition.apache;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/DefaultHttpClientDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/DefaultHttpClientDefinition.java
@@ -13,7 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/plugin/feign/http/v9/define/DefaultHttpClientInstrumentation.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.gray.feign.definition;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/HttpClientDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/HttpClientDefinition.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -12,6 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Based on com/huawei/apm/plugin/feign/http/v9/define/HttpClientInstrumentation.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.gray.feign.definition;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/PathVarDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/PathVarDefinition.java
@@ -13,7 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/plugin/feign/http/v9/define/PathVarInstrumentation.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.gray.feign.definition;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/DefaultHttpClientInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/DefaultHttpClientInterceptor.java
@@ -13,7 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/plugin/feign/http/v9/DefaultHttpClientInterceptor.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.gray.feign.interceptor;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/PathVarInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/PathVarInterceptor.java
@@ -13,7 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/plugin/feign/http/v9/PathVarInterceptor.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.gray.feign.interceptor;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/service/DefaultHttpClientService.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/service/DefaultHttpClientService.java
@@ -13,7 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/plugin/feign/http/v9/DefaultHttpClientInterceptor.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.gray.feign.service;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/service/PathVarService.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/service/PathVarService.java
@@ -13,7 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/plugin/feign/http/v9/PathVarInterceptor.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.gray.feign.service;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/context/FeignResolvedURL.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/context/FeignResolvedURL.java
@@ -13,7 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/plugin/feign/http/v9/FeignResolvedURL.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.gray.feign.context;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/service/DefaultHttpClientServiceImpl.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/service/DefaultHttpClientServiceImpl.java
@@ -13,7 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/plugin/feign/http/v9/DefaultHttpClientInterceptor.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.gray.feign.service;

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/service/PathVarServiceImpl.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/service/PathVarServiceImpl.java
@@ -13,7 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/plugin/feign/http/v9/PathVarInterceptor.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.gray.feign.service;

--- a/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/provider/OpenJvmMetricProvider.java
+++ b/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/provider/OpenJvmMetricProvider.java
@@ -13,7 +13,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ */
+
+/*
+ * Based on org/apache/skywalking/apm/agent/core/jvm/JVMService.java
+ * from the Apache Skywalking project.
  */
 
 package com.huawei.javamesh.sample.servermonitor.provider;


### PR DESCRIPTION
This is PR is for 井号164

**What type is this PR:**

/doc

**What this PR does / why we need it:**

This is PR is for 井号164. This project is currently not mature yet, and is being improved in many ways. One of the issue we recently found is the wrong way of referring Apache SkyWalking's work.  

 - The javaagent's plugin design architecture is referred to Apache Skywalking. This needs to be mentioned in README.
 - Some classes from the agent core project are copied from Apache Skywalking, but with wrong declaration way.  Correct legal header needs to be updated in these files. 
      -  All these classes are specifically located in `com.huawei.javamesh.core.agent`. Plugin Manager should be addressed as well.
      -  Corresponding plugin samples needs to be listed as well, specifically in the instrumentation-function part of code.
 - Need to list those jars License information in the License file in the binary release.

**Which issue(s) this PR fixes:**

井号164

**Special notes for your reviewer:** This PR needs skywalking team to be reviewed.

**Use case description:** NA

**Does this PR introduce a user-facing change?**

No

**Additional documentation e.g., usage docs, etc.:**

No
