### PR TITLE
【enhancement】backend添加修改配置服务，添加logback日志

### DIFF
--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/master/RegionMasterService.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/master/RegionMasterService.java
@@ -53,9 +53,9 @@ public class RegionMasterService extends AbstractMasterService {
 
     private static final Logger LOGGER = LogFactory.getLogger();
 
-    private final static String REGISTER_URL = "/apm2/master/v1/register";
+    private final static String REGISTER_URL = "/sermant/master/v1/register";
 
-    private final static String HEARTBEAT_URL = "/apm2/master/v1/heartbeat";
+    private final static String HEARTBEAT_URL = "/sermant/master/v1/heartbeat";
 
     /**
      * master地址列表

--- a/javamesh-backend/pom.xml
+++ b/javamesh-backend/pom.xml
@@ -92,6 +92,24 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper-jute</artifactId>
+            <version>3.6.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/Config.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/Config.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig;
+
+import com.huawei.javamesh.backend.service.dynamicconfig.service.DynamicConfigType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ *
+ * Config for this DynamicConfig Module
+ *
+ */
+public class Config {
+
+    private static final Logger logger = LoggerFactory.getLogger(Config.class);
+
+    static Config singleInst;
+
+    public synchronized static Config getInstance()
+    {
+        if ( singleInst == null ) {
+            logger.warn("Config failed to init from configfile. Load config from hardcode.");
+            singleInst = new Config();
+        }
+        return singleInst;
+    }
+
+    public static int getTimeout_value() {
+        return getInstance().timeout_value;
+    }
+
+    public static String getDefaultGroup() {
+        return getInstance().default_group;
+    }
+
+    public static String getZookeeperUri() {
+        return getInstance().zookeeper_uri;
+    }
+
+    public static DynamicConfigType getDynamic_config_type() {
+        return getInstance().dynamic_config_type;
+    }
+
+
+    protected void setTimeout_value(int timeout_value) {
+        this.timeout_value = timeout_value;
+    }
+
+    protected void setDefault_group(String default_group) {
+        this.default_group = default_group;
+    }
+
+    protected void setZookeeper_uri(String zookeeper_uri) {
+        this.zookeeper_uri = zookeeper_uri;
+    }
+
+    protected void setDynamic_config_type(DynamicConfigType dynamicConfigType) {
+        this.dynamic_config_type = dynamicConfigType;
+    }
+
+    protected int timeout_value = 30000;
+
+    protected String default_group = "java-mesh";
+
+    protected String zookeeper_uri = "zookeeper://127.0.0.1:2181";
+
+    protected DynamicConfigType dynamic_config_type = DynamicConfigType.ZOO_KEEPER; //DynamicConfigType.ZOO_KEEPER;
+
+    /**
+     * kie配置地址
+     */
+    protected String kie_url = "http://127.0.0.1:30110";
+
+    /**
+     * 默认kie的命名空间
+     */
+    protected String project = "default";
+
+    public String getKie_url() {
+        return kie_url;
+    }
+
+    public void setKie_url(String kie_url) {
+        this.kie_url = kie_url;
+    }
+
+    public String getProject() {
+        return project;
+    }
+
+    public void setProject(String project) {
+        this.project = project;
+    }
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/DynamicConfigurationFactoryServiceImpl.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/DynamicConfigurationFactoryServiceImpl.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig;
+
+import com.huawei.javamesh.backend.service.dynamicconfig.kie.KieDynamicConfigurationServiceImpl;
+import com.huawei.javamesh.backend.service.dynamicconfig.nop.NopDynamicConfigurationService;
+import com.huawei.javamesh.backend.service.dynamicconfig.service.DynamicConfigType;
+import com.huawei.javamesh.backend.service.dynamicconfig.service.DynamicConfigurationFactoryService;
+import com.huawei.javamesh.backend.service.dynamicconfig.service.DynamicConfigurationService;
+import com.huawei.javamesh.backend.service.dynamicconfig.zookeeper.ZookeeperDynamicConfigurationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+
+/**
+ *
+ * The implementation for the DynamicConfigurationFactoryService
+ *
+ */
+@Component
+public class DynamicConfigurationFactoryServiceImpl implements DynamicConfigurationFactoryService {
+
+    private static final Logger logger = LoggerFactory.getLogger(DynamicConfigurationFactoryServiceImpl.class);
+
+    protected DynamicConfigurationService getDynamicConfigurationService(DynamicConfigType dct) {
+
+        if ( dct == DynamicConfigType.ZOO_KEEPER )
+            return ZookeeperDynamicConfigurationService.getInstance();
+
+        if ( dct == DynamicConfigType.KIE )
+            return KieDynamicConfigurationServiceImpl.getInstance();
+
+        if ( dct == DynamicConfigType.NOP )
+            return NopDynamicConfigurationService.getInstance();
+
+        return null;
+    }
+
+    @Override
+    public DynamicConfigurationService getDynamicConfigurationService() {
+        return this.getDynamicConfigurationService(Config.getDynamic_config_type());
+    }
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/KieDynamicConfigurationServiceImpl.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/KieDynamicConfigurationServiceImpl.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.kie;
+
+import com.huawei.javamesh.backend.service.dynamicconfig.Config;
+import com.huawei.javamesh.backend.service.dynamicconfig.kie.listener.SubscriberManager;
+import com.huawei.javamesh.backend.service.dynamicconfig.service.ConfigurationListener;
+import com.huawei.javamesh.backend.service.dynamicconfig.service.DynamicConfigurationService;
+import com.huawei.javamesh.backend.service.dynamicconfig.utils.LabelGroupUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * kie配置中心实现
+ * <p></p>
+ *
+ * @author zhouss
+ * @since 2021-11-22
+ */
+public class KieDynamicConfigurationServiceImpl implements DynamicConfigurationService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(KieDynamicConfigurationServiceImpl.class);
+
+    private static SubscriberManager subscriberManager;
+
+    private static KieDynamicConfigurationServiceImpl instance;
+
+    private final Map<String, List<String>> groupKeyCache = new ConcurrentHashMap<String, List<String>>();
+
+    private KieDynamicConfigurationServiceImpl() {
+
+    }
+
+    /**
+     * 获取实现单例
+     *
+     * @return KieDynamicConfigurationService
+     */
+    public static synchronized KieDynamicConfigurationServiceImpl getInstance() {
+        if (instance == null) {
+            instance = new KieDynamicConfigurationServiceImpl();
+            subscriberManager = new SubscriberManager(Config.getInstance().getKie_url());
+        }
+        return instance;
+    }
+
+    @Override
+    public boolean removeGroupListener(String key, String group, ConfigurationListener listener) {
+        return updateListener("GroupKey", group, listener, false);
+    }
+
+    @Override
+    public boolean addGroupListener(String group, ConfigurationListener listener) {
+        return updateListener("GroupKey", group, listener, true);
+    }
+
+    @Override
+    public boolean addConfigListener(String key, String group, ConfigurationListener listener) {
+        return updateListener(key, LabelGroupUtils.createLabelGroup(
+                Collections.singletonMap(fixSeparator(group, true), fixSeparator(key, false))),
+                listener, true);
+    }
+
+    @Override
+    public boolean removeConfigListener(String key, String group, ConfigurationListener listener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getConfig(String key, String group) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean publishConfig(String key, String group, String content) {
+        return subscriberManager.publishConfig(key, group, content);
+    }
+
+    @Override
+    public String getDefaultGroup() {
+        return "java-mesh";
+    }
+
+    @Override
+    public long getDefaultTimeout() {
+        return 0;
+    }
+
+    @Override
+    public List<String> listConfigsFromGroup(String group) {
+        return groupKeyCache.get(group);
+    }
+
+    /**
+     * 更新监听器（删除||添加）
+     * 若第一次添加监听器，则会将数据通知给监听器
+     *
+     * @param key          监听键
+     * @param group        分组， 针对KIE特别处理生成group方法{@link LabelGroupUtils#createLabelGroup(Map)}
+     * @param listener     对应改组的监听器
+     * @param forSubscribe 是否为订阅
+     * @return 更新是否成功
+     */
+    private synchronized boolean updateListener(String key, String group, ConfigurationListener listener, boolean forSubscribe) {
+        updateGroupKey(key, group, forSubscribe);
+        try {
+            if (forSubscribe) {
+                return subscriberManager.addGroupListener(group, listener);
+            } else {
+                return subscriberManager.removeGroupListener(group, listener);
+            }
+        } catch (Exception exception) {
+            LOGGER.warn("Subscribed kie request failed! raw key : " + key);
+            return false;
+        }
+    }
+
+    private void updateGroupKey(String key, String group, boolean forSubscribe) {
+        List<String> keys = groupKeyCache.get(group);
+        if (keys == null) {
+            keys = new ArrayList<>();
+        }
+        if (forSubscribe) {
+            keys.remove(key);
+        } else {
+            keys.add(key);
+        }
+        groupKeyCache.put(group, keys);
+    }
+
+    /**
+     * 去除路径分隔符
+     *
+     * @param str key or group
+     * @param isGroup 是否为组
+     * @return 修正值
+     */
+    private String fixSeparator(String str, boolean isGroup) {
+        if (str == null) {
+            if (isGroup) {
+                // 默认分组
+                str = getDefaultGroup();
+            } else {
+                throw new IllegalArgumentException("Key must not be empty!");
+            }
+        }
+        return str.startsWith("/") ? str.substring(1) : str;
+    }
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/AbstractClient.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/AbstractClient.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.kie.client;
+
+import com.huawei.javamesh.backend.service.dynamicconfig.kie.client.http.DefaultHttpClient;
+import com.huawei.javamesh.backend.service.dynamicconfig.kie.client.http.HttpClient;
+
+/**
+ * 抽象客户端
+ *
+ * @author zhouss
+ * @since 2021-11-17
+ */
+public abstract class AbstractClient implements Client {
+    protected final ClientUrlManager clientUrlManager;
+
+    protected HttpClient httpClient;
+
+    protected AbstractClient(ClientUrlManager clientUrlManager) {
+        this.clientUrlManager = clientUrlManager;
+        initDefaultClient();
+    }
+
+    protected AbstractClient(ClientUrlManager clientUrlManager, HttpClient httpClient) {
+        this.clientUrlManager = clientUrlManager;
+        if (httpClient != null) {
+            this.httpClient = httpClient;
+        } else {
+            initDefaultClient();
+        }
+    }
+
+    private void initDefaultClient() {
+        this.httpClient = new DefaultHttpClient();
+    }
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/Client.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/Client.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.kie.client;
+
+/**
+ * 客户端
+ *
+ * @author zhouss
+ * @since 2021-11-17
+ */
+public interface Client {
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/ClientUrlManager.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/ClientUrlManager.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.kie.client;
+
+import com.huawei.javamesh.backend.service.dynamicconfig.kie.selector.url.UrlSelector;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * 客户端请求地址管理器
+ *
+ * @author zhouss
+ * @since 2021-11-17
+ */
+public class ClientUrlManager {
+    private final UrlSelector urlSelector = new UrlSelector();
+    private List<String> urls;
+
+    public ClientUrlManager(String urls) {
+        resolveUrls(urls);
+    }
+
+    /**
+     * 客户端请求地址
+     *
+     * @return url
+     */
+    public String getUrl() {
+        return urlSelector.select(urls);
+    }
+
+    /**
+     * 解析url
+     * 默认多个url使用逗号隔开
+     *
+     * @param rawUrls url字符串
+     */
+    public void resolveUrls(String rawUrls) {
+        if (rawUrls == null || rawUrls.trim().length() == 0) {
+            return;
+        }
+        urls = Arrays.asList(rawUrls.split(","));
+    }
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/http/DefaultHttpClient.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/http/DefaultHttpClient.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.kie.client.http;
+
+import com.alibaba.fastjson.JSONObject;
+import com.huawei.javamesh.backend.service.dynamicconfig.kie.listener.SubscriberManager;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * HTTP客户端
+ *
+ * @author zhouss
+ * @since 2021-11-17
+ */
+public class DefaultHttpClient implements com.huawei.javamesh.backend.service.dynamicconfig.kie.client.http.HttpClient {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultHttpClient.class);
+    /**
+     * 默认超时时间
+     */
+    private static final int DEFAULT_TIMEOUT_MS = 5000;
+
+    /**
+     * 最大的连接数
+     * 该值建议 > {@link SubscriberManager}最大线程数MAX_THREAD_SIZE
+     */
+    private static final int MAX_TOTAL = SubscriberManager.MAX_THREAD_SIZE * 2;
+
+    /**
+     * 没分支最大连接数
+     */
+    private static final int DEFAULT_MAX_PER_ROUTE = 10;
+
+    private final HttpClient httpClient;
+
+    public DefaultHttpClient() {
+        httpClient = HttpClientBuilder.create().setDefaultRequestConfig(
+                RequestConfig.custom().setConnectTimeout(DEFAULT_TIMEOUT_MS)
+                        .setSocketTimeout(DEFAULT_TIMEOUT_MS)
+                        .setConnectionRequestTimeout(DEFAULT_TIMEOUT_MS)
+                        .build()
+        ).setConnectionManager(buildConnectionManager()).build();
+    }
+
+    public DefaultHttpClient(RequestConfig requestConfig) {
+        this.httpClient = HttpClientBuilder.create()
+                .setDefaultRequestConfig(requestConfig)
+                .setConnectionManager(buildConnectionManager())
+                .build();
+    }
+
+
+    /**
+     * 配置连接池的主要目的是防止在发送请求时连接不够导致无法请求
+     * 特别是针对订阅者
+     *
+     * @return PoolingHttpClientConnectionManager
+     */
+    private PoolingHttpClientConnectionManager buildConnectionManager() {
+        RegistryBuilder<ConnectionSocketFactory> builder = RegistryBuilder.create();
+        builder.register("http", PlainConnectionSocketFactory.INSTANCE);
+        // 如果需配置SSL 在此处注册https
+        Registry<ConnectionSocketFactory> connectionSocketFactoryRegistry = builder.build();
+
+        //connection pool management
+        PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager(
+                connectionSocketFactoryRegistry);
+        connectionManager.setMaxTotal(MAX_TOTAL);
+        connectionManager.setDefaultMaxPerRoute(DEFAULT_MAX_PER_ROUTE);
+        return connectionManager;
+    }
+
+    /**
+     * get请求
+     *
+     * @param url 请求地址
+     * @return HttpResult
+     */
+    @Override
+    public HttpResult doGet(String url) {
+        return doGet(url, null, null);
+    }
+
+    @Override
+    public HttpResult doGet(String url, RequestConfig requestConfig) {
+        return doGet(url, null, requestConfig);
+    }
+
+    /**
+     * get请求
+     *
+     * @param url 请求地址
+     * @param headers 请求头
+     * @return HttpResult
+     */
+    @Override
+    public HttpResult doGet(String url, Map<String, String> headers, RequestConfig requestConfig) {
+        final HttpGet httpGet = new HttpGet(url);
+        beforeRequest(httpGet, requestConfig, headers);
+        return execute(httpGet);
+    }
+
+    @Override
+    public HttpResult doPost(String url, Map<String, Object> params) {
+        return doPost(url, params, null);
+    }
+
+    @Override
+    public HttpResult doPost(String url, Map<String, Object> params, RequestConfig requestConfig) {
+        return doPost(url, params, requestConfig, new HashMap<>());
+    }
+
+    @Override
+    public HttpResult doPost(String url, Map<String, Object> params, RequestConfig requestConfig, Map<String, String> headers) {
+        HttpPost httpPost = new HttpPost(url);
+        beforeRequest(httpPost, requestConfig, headers);
+        addParams(httpPost, params);
+        return execute(httpPost);
+    }
+
+    /**
+     * 执行请求
+     *
+     * @param request 请求参数
+     * @return HttpResult
+     */
+    private HttpResult execute(HttpUriRequest request) {
+        HttpEntity entity = null;
+        HttpResponse response = null;
+        String result = null;
+        try {
+            response = this.httpClient.execute(request);
+            if (response == null) {
+                return HttpResult.error();
+            }
+            entity = response.getEntity();
+            if (entity == null) {
+                return new HttpResult(response.getStatusLine().getStatusCode(), "", response.getAllHeaders());
+            }
+            result = EntityUtils.toString(entity, "UTF-8");
+        } catch (IOException ex) {
+            LOGGER.warn(String.format("Execute request failed, %s", ex.getMessage()));
+        } finally {
+            consumeEntity(entity);
+        }
+        if (response == null) {
+            return HttpResult.error();
+        }
+        return new HttpResult(response.getStatusLine().getStatusCode(), result, response.getAllHeaders());
+    }
+
+    private void consumeEntity(HttpEntity entity) {
+        try {
+            EntityUtils.consume(entity);
+        } catch (IOException ex) {
+            LOGGER.warn(String.format("Consumed http entity failed, %s", ex.getMessage()));
+        }
+    }
+
+    private void addParams(HttpPost httpPost, Map<String, Object> params) {
+        if (params == null || params.isEmpty()) {
+            return;
+        }
+        httpPost.setEntity(new StringEntity(JSONObject.toJSONString(params), ContentType.APPLICATION_JSON));
+    }
+
+    private void beforeRequest(HttpRequestBase httpRequest, RequestConfig requestConfig, Map<String, String> headers) {
+        addDefaultHeaders(httpRequest);
+        addHeaders(httpRequest, headers);
+        if (requestConfig != null) {
+            httpRequest.setConfig(requestConfig);
+        }
+    }
+
+    private void addHeaders(HttpRequestBase base, Map<String, String> headers) {
+        if (headers != null && !headers.isEmpty()) {
+            for (Map.Entry<String, String> entry : headers.entrySet()) {
+                base.addHeader(entry.getKey(), entry.getValue());
+            }
+        }
+    }
+
+    /**
+     * 添加默认的请求头
+     */
+    private void addDefaultHeaders(HttpRequestBase base) {
+        base.addHeader(HttpHeaders.CONTENT_TYPE, "application/json; charset=utf-8");
+        base.addHeader(HttpHeaders.USER_AGENT, "java-mesh/client");
+    }
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/http/HttpClient.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/http/HttpClient.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.kie.client.http;
+
+import com.huawei.javamesh.backend.service.dynamicconfig.kie.client.Client;
+import org.apache.http.client.config.RequestConfig;
+
+import java.util.Map;
+
+/**
+ * http请求
+ *
+ * @author zhouss
+ * @since 2021-11-17
+ */
+public interface HttpClient extends Client {
+
+    /**
+     * get请求
+     *
+     * @param url 请求地址
+     * @param headers 请求头
+     * @param requestConfig 请求配置
+     * @return HttpResult
+     */
+    HttpResult doGet(String url, Map<String, String> headers, RequestConfig requestConfig);
+
+    /**
+     * get请求
+     *
+     * @param url 请求地址
+     * @return HttpResult
+     */
+    HttpResult doGet(String url);
+
+    /**
+     * get请求
+     *
+     * @param url 请求地址
+     * @param requestConfig 请求配置
+     * @return HttpResult
+     */
+    HttpResult doGet(String url, RequestConfig requestConfig);
+
+    /**
+     * post请求
+     *
+     * @param url 请求地址
+     * @param params 请求参数
+     * @return HttpResult
+     */
+    HttpResult doPost(String url, Map<String, Object> params);
+
+    /**
+     * post请求
+     *
+     * @param url 请求地址
+     * @param params 请求参数
+     * @param requestConfig 请求配置
+     * @return HttpResult
+     */
+    HttpResult doPost(String url, Map<String, Object> params,  RequestConfig requestConfig);
+
+    /**
+     * post请求
+     *
+     * @param url 请求地址
+     * @param params 请求参数
+     * @param headers 请求头
+     * @param requestConfig 请求配置
+     * @return HttpResult
+     */
+    HttpResult doPost(String url, Map<String, Object> params, RequestConfig requestConfig, Map<String, String> headers);
+
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/http/HttpResult.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/http/HttpResult.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.kie.client.http;
+
+import org.apache.http.Header;
+import org.apache.http.HttpStatus;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * httpclient响应结果
+ *
+ * @author zhouss
+ * @since 2021-11-17
+ */
+public class HttpResult {
+    /**
+     * 错误请求响应码
+     */
+    public static final int ERROR_CODE = -1;
+
+    /**
+     * 可接受编号
+     * SC_OK : 正常返回
+     * SC_NOT_MODIFIED : 未做任何修改
+     */
+    private final int[] OK_CODES = {HttpStatus.SC_OK, HttpStatus.SC_NOT_MODIFIED};
+
+    /**
+     * 响应码
+     */
+    private int code;
+
+    /**
+     * 响应结果
+     */
+    private String result;
+
+    private Map<String, Object> responseHeaders;
+
+    public HttpResult(int code, String result, Header[] headers) {
+        this.code = code;
+        this.result = result;
+        if (headers != null) {
+            responseHeaders = new HashMap<String, Object>(headers.length);
+            for (Header header : headers) {
+                responseHeaders.put(header.getName(), header.getValue());
+            }
+        }
+    }
+
+    /**
+     * 错误响应结果
+     *
+     * @return HttpResult
+     */
+    public static HttpResult error() {
+        return new HttpResult(ERROR_CODE, null, null);
+    }
+
+    /**
+     * 响应是否出错
+     *
+     * @return 是否错误响应
+     */
+    public boolean isError() {
+        for (int okCode : OK_CODES) {
+            if (okCode == this.code) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public void setCode(int code) {
+        this.code = code;
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    public Map<String, Object> getResponseHeaders() {
+        return responseHeaders;
+    }
+
+    public void setResponseHeaders(Map<String, Object> responseHeaders) {
+        this.responseHeaders = responseHeaders;
+    }
+
+    public void setResult(String result) {
+        this.result = result;
+    }
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/KieClient.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/KieClient.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.kie.client.kie;
+
+import com.huawei.javamesh.backend.service.dynamicconfig.Config;
+import com.huawei.javamesh.backend.service.dynamicconfig.kie.client.AbstractClient;
+import com.huawei.javamesh.backend.service.dynamicconfig.kie.client.ClientUrlManager;
+import com.huawei.javamesh.backend.service.dynamicconfig.kie.client.http.HttpClient;
+import com.huawei.javamesh.backend.service.dynamicconfig.kie.client.http.HttpResult;
+import org.apache.http.HttpStatus;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * kie客户端
+ *
+ * @author zhouss
+ * @since 2021-11-17
+ */
+public class KieClient extends AbstractClient {
+
+    private final ResultHandler<KieResponse> defaultHandler = new ResultHandler.DefaultResultHandler();
+
+    private final String kieApiTemplate = "/v1/%s/kie/kv?";
+
+    private String kieApi;
+
+    public KieClient(ClientUrlManager clientUrlManager) {
+        this(clientUrlManager, Config.getInstance().getProject());
+    }
+
+    public KieClient(ClientUrlManager clientUrlManager, String project) {
+        this(clientUrlManager, null, project);
+    }
+
+    public KieClient(ClientUrlManager clientUrlManager, HttpClient httpClient, String project) {
+        super(clientUrlManager, httpClient);
+        kieApi = String.format(kieApiTemplate, project);
+    }
+
+    public void setProject(String project) {
+        this.kieApi = String.format(kieApiTemplate, project);
+    }
+
+    /**
+     * 插叙Kie配置
+     *
+     * @param request 请求体
+     * @return KieResponse
+     */
+    public KieResponse queryConfigurations(KieRequest request) {
+        return queryConfigurations(request, defaultHandler);
+    }
+
+    /**
+     * 查询Kie配置
+     *
+     * @param request 请求体
+     * @param responseHandler http结果处理器
+     * @param <T> 转换后的目标类型
+     * @return 响应结果
+     */
+    public <T> T queryConfigurations(KieRequest request, ResultHandler<T> responseHandler) {
+        if (request == null || responseHandler == null) {
+            return null;
+        }
+        final StringBuilder requestUrl = new StringBuilder().append(clientUrlManager.getUrl()).append(kieApi);
+        requestUrl.append(formatNullString(request.getLabelCondition()))
+                .append("&revision=")
+                .append(formatNullString(request.getRevision()));
+        if (request.isAccurateMatchLabel()) {
+            requestUrl.append("&match=exact");
+        }
+        if (request.getWait() != null) {
+            requestUrl.append("&wait=").append(formatNullString(request.getWait())).append("s");
+        }
+        final HttpResult httpResult = httpClient.doGet(requestUrl.toString(), request.getRequestConfig());
+        return responseHandler.handle(httpResult);
+    }
+
+    /**
+     * 发布配置
+     *
+     * @param key 请求键
+     * @param labels 标签
+     * @param content 配置
+     * @return 是否发布成功
+     */
+    public boolean publishConfig(String key, Map<String, String> labels, String content, boolean enabled) {
+        final Map<String, Object> params = new HashMap<>();
+        params.put("key", key);
+        params.put("value", content);
+        params.put("labels", labels);
+        params.put("status", enabled ? "enabled" : "disabled");
+        final HttpResult httpResult = this.httpClient.doPost(clientUrlManager.getUrl() + kieApi, params);
+        return httpResult.getCode() == HttpStatus.SC_OK;
+    }
+
+    private String formatNullString(String val) {
+        if (val == null || val.trim().length() == 0) {
+            return "";
+        }
+        return val;
+    }
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/KieConfigEntity.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/KieConfigEntity.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.kie.client.kie;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Kie响应单个配置实体
+ *
+ * @author zhouss
+ * @since 2021-11-17
+ */
+public class KieConfigEntity {
+    private String id;
+    private String key;
+    private Map<String, String> labels = new HashMap<String, String>();
+    private String value;
+    private String valueType;
+    private String status;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public Map<String, String> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(Map<String, String> labels) {
+        this.labels = labels;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getValueType() {
+        return valueType;
+    }
+
+    public void setValueType(String valueType) {
+        this.valueType = valueType;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/KieListenerWrapper.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/KieListenerWrapper.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.kie.client.kie;
+
+import com.huawei.javamesh.backend.service.dynamicconfig.kie.listener.KvDataHolder;
+import com.huawei.javamesh.backend.service.dynamicconfig.kie.listener.SubscriberManager;
+import com.huawei.javamesh.backend.service.dynamicconfig.service.ConfigChangeType;
+import com.huawei.javamesh.backend.service.dynamicconfig.service.ConfigChangedEvent;
+import com.huawei.javamesh.backend.service.dynamicconfig.service.ConfigurationListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * listener封装，关联任务执行器
+ *
+ * @author zhouss
+ * @since 2021-11-18
+ */
+public class KieListenerWrapper {
+    private static final Logger LOGGER = LoggerFactory.getLogger(KieListenerWrapper.class);
+
+    private ConfigurationListener configurationListener;
+
+    private SubscriberManager.Task task;
+
+    private String group;
+
+    private final KvDataHolder kvDataHolder;
+
+    public void notifyListener(KvDataHolder.EventDataHolder eventDataHolder) {
+        if (!eventDataHolder.getAdded().isEmpty()) {
+            // 新增事件
+            notify(eventDataHolder.getAdded(), ConfigChangeType.ADDED);
+        }
+        if (!eventDataHolder.getDeleted().isEmpty()) {
+            // 删除事件
+            notify(eventDataHolder.getDeleted(), ConfigChangeType.DELETED);
+        }
+        if (!eventDataHolder.getModified().isEmpty()) {
+            // 修改事件
+            notify(eventDataHolder.getModified(), ConfigChangeType.MODIFIED);
+        }
+    }
+
+    private void notify(Map<String, String> configData, ConfigChangeType configChangeType) {
+        for (Map.Entry<String, String> entry : configData.entrySet()) {
+            try {
+                configurationListener.process(new ConfigChangedEvent(entry.getKey(), this.group, entry.getValue(),
+                        configChangeType));
+            } catch (Throwable ex) {
+                LOGGER.warn(String.format(Locale.ENGLISH, "Process config data failed, key: [%s], group: [%s]",
+                        entry.getKey(), this.group));
+            }
+        }
+    }
+
+    public KieListenerWrapper(ConfigurationListener configurationListener, SubscriberManager.Task task,
+                              KvDataHolder kvDataHolder) {
+        this.configurationListener = configurationListener;
+        this.task = task;
+        this.kvDataHolder = kvDataHolder;
+    }
+
+    public KieListenerWrapper(String group, ConfigurationListener configurationListener, KvDataHolder kvDataHolder) {
+        this.group = group;
+        this.configurationListener = configurationListener;
+        this.kvDataHolder = kvDataHolder;
+    }
+
+    public ConfigurationListener getConfigurationListener() {
+        return configurationListener;
+    }
+
+    public void setConfigurationListener(ConfigurationListener configurationListener) {
+        this.configurationListener = configurationListener;
+    }
+
+    public SubscriberManager.Task getTask() {
+        return task;
+    }
+
+    public void setTask(SubscriberManager.Task task) {
+        this.task = task;
+    }
+
+    public KvDataHolder getKvDataHolder() {
+        return kvDataHolder;
+    }
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/KieRequest.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/KieRequest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.kie.client.kie;
+
+import org.apache.http.client.config.RequestConfig;
+
+/**
+ * kie请求体
+ *
+ * @author zhouss
+ * @since 2021-11-17
+ */
+public class KieRequest {
+    /**
+     * 标签条件
+     * 例如label=version:1.0  查询含标签版本为1.0的kv
+     */
+    private String labelCondition;
+
+    /**
+     * 与kie建立连接等待时间，单位S
+     * 在这段时间会一直等待，如果相关kie有变更则会返回
+     * 官方说明：
+     * "wait until any kv changed. for example wait=5s, server will not response until 5 seconds,
+     * during that time window, if any kv changed, server will return 200 and kv list,
+     * otherwise return 304 and empty body",
+     *
+     * 建议时间不超过50s,超过50s的将以50s计算
+     */
+    private String wait;
+
+    /**
+     * 请求版本
+     * 若配置中心版本高于当前版本，则会返回新数据
+     */
+    private String revision;
+
+    /**
+     * http请求配置
+     */
+    private RequestConfig requestConfig;
+
+    /**
+     * 匹配标签
+     * true : 精确匹配标签的kv
+     * false : 匹配包含labelCondition的所有kv
+     */
+    private boolean accurateMatchLabel = true;
+
+    public RequestConfig getRequestConfig() {
+        return requestConfig;
+    }
+
+    public void setRequestConfig(RequestConfig requestConfig) {
+        this.requestConfig = requestConfig;
+    }
+
+    public String getLabelCondition() {
+        return labelCondition;
+    }
+
+    public KieRequest setLabelCondition(String labelCondition) {
+        this.labelCondition = labelCondition;
+        return this;
+    }
+
+    public boolean isAccurateMatchLabel() {
+        return accurateMatchLabel;
+    }
+
+    public void setAccurateMatchLabel(boolean accurateMatchLabel) {
+        this.accurateMatchLabel = accurateMatchLabel;
+    }
+
+    public String getWait() {
+        return wait;
+    }
+
+    public KieRequest setWait(String wait) {
+        this.wait = wait;
+        return this;
+    }
+
+    public String getRevision() {
+        return revision;
+    }
+
+    public KieRequest setRevision(String revision) {
+        this.revision = revision;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        KieRequest that = (KieRequest) obj;
+
+        return labelCondition != null ? labelCondition.equals(that.labelCondition) : that.labelCondition == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return labelCondition != null ? labelCondition.hashCode() : 0;
+    }
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/KieResponse.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/KieResponse.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.kie.client.kie;
+
+import java.util.List;
+
+/**
+ * 响应结果
+ *
+ * @author zhouss
+ * @since 2021-11-17
+ */
+public class KieResponse {
+    /**
+     * 配置总数
+     */
+    private Integer total;
+
+    /**
+     * kv数据
+     */
+    private List<KieConfigEntity> data;
+
+    /**
+     * 响应版本
+     */
+    private String revision;
+
+    /**
+     * 是否改变
+     */
+    private boolean changed = true;
+
+    public String getRevision() {
+        return revision;
+    }
+
+    public void setRevision(String revision) {
+        this.revision = revision;
+    }
+
+    public Integer getTotal() {
+        return total;
+    }
+
+    public void setTotal(Integer total) {
+        this.total = total;
+    }
+
+    public List<KieConfigEntity> getData() {
+        return data;
+    }
+
+    public void setData(List<KieConfigEntity> data) {
+        this.data = data;
+    }
+
+    public boolean isChanged() {
+        return changed;
+    }
+
+    public void setChanged(boolean changed) {
+        this.changed = changed;
+    }
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/KieSubscriber.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/KieSubscriber.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.kie.client.kie;
+
+/**
+ * 增加是否为长请求判断
+ *
+ * @author zhouss
+ * @since 2021-11-18
+ */
+public class KieSubscriber {
+    /**
+     * 最大等待时间
+     * 50S
+     */
+    private static final int MAX_WAIT = 50;
+
+    private Boolean isLongConnectionRequest;
+
+    private final KieRequest kieRequest;
+
+    public KieSubscriber(KieRequest kieRequest) {
+        this.kieRequest = kieRequest;
+    }
+
+    /**
+     * 是否为长请求
+     *
+     * @return boolean
+     */
+    public boolean isLongConnectionRequest() {
+        String wait = kieRequest.getWait();
+        if (this.isLongConnectionRequest != null) {
+            return this.isLongConnectionRequest;
+        }
+        if (wait == null || wait.trim().length() == 0) {
+            this.isLongConnectionRequest = false;
+            return false;
+        }
+        try {
+            final int parseWait = Integer.parseInt(wait);
+            this.isLongConnectionRequest = parseWait >= 1;
+            if (parseWait > MAX_WAIT) {
+                kieRequest.setWait(String.valueOf(MAX_WAIT));
+            }
+        } catch (Exception ex) {
+            this.isLongConnectionRequest = false;
+        }
+        return this.isLongConnectionRequest;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        KieSubscriber that = (KieSubscriber) obj;
+
+        if (!isLongConnectionRequest.equals(that.isLongConnectionRequest)) {
+            return false;
+        }
+        return kieRequest != null ? kieRequest.equals(that.kieRequest) : that.kieRequest == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = ((isLongConnectionRequest == null || !isLongConnectionRequest)  ? 1 : 0);
+        result = 31 * result + (kieRequest != null ? kieRequest.hashCode() : 0);
+        return result;
+    }
+
+    public KieRequest getKieRequest() {
+        return kieRequest;
+    }
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/ResultHandler.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/ResultHandler.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.kie.client.kie;
+
+import com.alibaba.fastjson.JSONObject;
+import com.huawei.javamesh.backend.service.dynamicconfig.kie.client.http.HttpResult;
+import org.apache.http.HttpStatus;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Kie结果处理器
+ *
+ * @author zhouss
+ * @since 2021-11-17
+ */
+public interface ResultHandler<R> {
+    /**
+     * 处理响应结果
+     *
+     * @param result 响应
+     * @return R
+     */
+    R handle(HttpResult result);
+
+    /**
+     * 默认结果处理器
+     */
+    class DefaultResultHandler implements ResultHandler<KieResponse> {
+        private final boolean onlyEnabled;
+        public DefaultResultHandler() {
+            onlyEnabled = true;
+        }
+
+        public DefaultResultHandler(boolean onlyEnabled) {
+            this.onlyEnabled = onlyEnabled;
+        }
+
+        @Override
+        public KieResponse handle(HttpResult result) {
+            if (result.isError()) {
+                return null;
+            }
+            final String content = result.getResult();
+            final KieResponse kieResponse = JSONObject.parseObject(content, KieResponse.class);
+            if (kieResponse == null) {
+                return null;
+            }
+            if (result.getCode() == HttpStatus.SC_NOT_MODIFIED) {
+                // KIE如果响应状态码为304，则表示没有相关键变更
+                kieResponse.setChanged(false);
+            }
+            // 过滤掉disabled的kv配置
+            final List<KieConfigEntity> data = kieResponse.getData();
+            if (data == null) {
+                return kieResponse;
+            }
+            kieResponse.setRevision(String.valueOf(result.getResponseHeaders().get("X-Kie-Revision")));
+            filter(data);
+            kieResponse.setTotal(data.size());
+            return kieResponse;
+        }
+        /**
+         * 过滤未开启的kv
+         *
+         * @param data kv列表
+         */
+        private void filter(List<KieConfigEntity> data) {
+            if (!onlyEnabled) {
+                return;
+            }
+            final Iterator<KieConfigEntity> iterator = data.iterator();
+            while (iterator.hasNext()) {
+                final KieConfigEntity next = iterator.next();
+                if ("disabled".equals(next.getStatus())) {
+                    iterator.remove();
+                }
+            }
+        }
+    }
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/constants/KieConstants.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/constants/KieConstants.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.kie.constants;
+
+/**
+ * Kie配置常量
+ *
+ * @author zhouss
+ * @since 2021-11-23
+ */
+public class KieConstants {
+    /**
+     * 核心线程数
+     */
+    public static final int CORE_THREAD_SIZE = 1;
+
+    /**
+     * 最大线程数
+     */
+    public static final int MAX_THREAD_SIZE = 3;
+
+    /**
+     * 队列长度
+     */
+    public static final int QUEUE_SIZE = 100;
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/listener/KvDataHolder.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/listener/KvDataHolder.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.kie.listener;
+
+import com.huawei.javamesh.backend.service.dynamicconfig.kie.client.kie.KieConfigEntity;
+import com.huawei.javamesh.backend.service.dynamicconfig.kie.client.kie.KieResponse;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 监听键响应数据
+ * 用于对比新旧数据并保留旧数据
+ *
+ * @author zhouss
+ * @since 2021-11-18
+ */
+public class KvDataHolder {
+    /**
+     * 当前数据
+     */
+    private Map<String, String> currentData;
+
+    /**
+     * 分析最新的数据
+     *
+     * @param response 最新数据
+     * @return EventDataHolder
+     */
+    public EventDataHolder analyzeLatestData(KieResponse response) {
+        final Map<String, String> latestData = formatKieResponse(response);
+        final EventDataHolder eventDataHolder = new EventDataHolder();
+        if (currentData != null) {
+            if (latestData.isEmpty()) {
+                eventDataHolder.deleted.putAll(currentData);
+            } else {
+                Map<String, String> temp = new HashMap<String, String>(currentData);
+                for (Map.Entry<String, String> entry : latestData.entrySet()) {
+                    final String value = currentData.get(entry.getKey());
+                    if (value == null) {
+                        // 增加的键
+                        eventDataHolder.added.put(entry.getKey(), entry.getValue());
+                    } else {
+                        // 如果存在该键，则比对值是否相等
+                        if (!value.equals(entry.getValue())) {
+                            // 修改
+                            eventDataHolder.modified.put(entry.getKey(), entry.getValue());
+                        }
+                    }
+                    temp.remove(entry.getKey());
+                }
+                // temp留下的键即为删除的
+                eventDataHolder.deleted.putAll(temp);
+            }
+        } else {
+            eventDataHolder.added.putAll(latestData);
+        }
+        currentData = latestData;
+        return eventDataHolder;
+    }
+
+    private Map<String, String> formatKieResponse(KieResponse response) {
+        final HashMap<String, String> latestData = new HashMap<String, String>();
+        if (response == null || response.getData() == null || response.getData().isEmpty()) {
+            return latestData;
+        }
+        for (KieConfigEntity entity : response.getData()) {
+            latestData.put(entity.getKey(), entity.getValue());
+        }
+        return latestData;
+    }
+
+    /**
+     * 数据变更
+     */
+    public static class EventDataHolder {
+        /**
+         * 修改的key
+         */
+        private Map<String, String> modified;
+
+        /**
+         * 删除的key
+         */
+        private Map<String, String> deleted;
+
+        /**
+         * 新增key
+         */
+        private Map<String, String> added;
+
+        public EventDataHolder() {
+            modified = new HashMap<String, String>();
+            deleted = new HashMap<String, String>();
+            added = new HashMap<String, String>();
+        }
+
+        public Map<String, String> getModified() {
+            return modified;
+        }
+
+        public void setModified(Map<String, String> modified) {
+            this.modified = modified;
+        }
+
+        public Map<String, String> getDeleted() {
+            return deleted;
+        }
+
+        public void setDeleted(Map<String, String> deleted) {
+            this.deleted = deleted;
+        }
+
+        public Map<String, String> getAdded() {
+            return added;
+        }
+
+        public void setAdded(Map<String, String> added) {
+            this.added = added;
+        }
+
+        public boolean isChanged() {
+            return !added.isEmpty() || !deleted.isEmpty() || !modified.isEmpty();
+        }
+    }
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/listener/SubscriberManager.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/listener/SubscriberManager.java
@@ -1,0 +1,474 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.kie.listener;
+
+import com.huawei.javamesh.backend.service.dynamicconfig.kie.client.ClientUrlManager;
+import com.huawei.javamesh.backend.service.dynamicconfig.kie.client.kie.KieClient;
+import com.huawei.javamesh.backend.service.dynamicconfig.kie.client.kie.KieListenerWrapper;
+import com.huawei.javamesh.backend.service.dynamicconfig.kie.client.kie.KieRequest;
+import com.huawei.javamesh.backend.service.dynamicconfig.kie.client.kie.KieResponse;
+import com.huawei.javamesh.backend.service.dynamicconfig.kie.client.kie.KieSubscriber;
+import com.huawei.javamesh.backend.service.dynamicconfig.service.ConfigurationListener;
+import com.huawei.javamesh.backend.service.dynamicconfig.utils.LabelGroupUtils;
+import com.huawei.javamesh.backend.util.BackendThreadFactory;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.client.config.RequestConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * 监听器管理
+ *
+ * @author zhouss
+ * @since 2021-11-17
+ */
+public class SubscriberManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SubscriberManager.class);
+
+    /**
+     * 最大线程数
+     */
+    public static final int MAX_THREAD_SIZE = 100;
+
+    /**
+     * 线程数
+     */
+    private static final int THREAD_SIZE = 5;
+
+    /**
+     * 秒转换为毫秒
+     */
+    private static final int SECONDS_UNIT = 1000;
+
+    /**
+     * 定时请求间隔
+     */
+    private static final int SCHEDULE_REQUEST_INTERVAL_MS = 5000;
+
+    /**
+     * 等待时间
+     */
+    private static final String WAIT = "20";
+
+    /**
+     * 长连接拉取间隔
+     */
+    private static final long LONG_CONNECTION_REQUEST_INTERVAL_MS = 2000L;
+
+    /**
+     * 当前长连接请求数
+     * 要求最大连接数必须小于 MAX_THREAD_SIZE
+     *
+     */
+    private final AtomicInteger curLongConnectionRequestCount = new AtomicInteger(0);
+
+    /**
+     * map<监听键, 监听该键的监听器列表>
+     */
+    private final Map<KieSubscriber, List<KieListenerWrapper>> listenerMap = new ConcurrentHashMap<KieSubscriber, List<KieListenerWrapper>>();
+
+    /**
+     * kie客户端
+     */
+    private final KieClient kieClient;
+
+    /**
+     * 订阅执行器
+     * 最大支持MAX_THREAD_SIZE个任务
+     * 由于是长连接请求，必然会占用线程，因此这里不考虑将任务存在队列中
+     */
+    private final ThreadPoolExecutor longRequestExecutor = new ThreadPoolExecutor(THREAD_SIZE, MAX_THREAD_SIZE,
+            0, TimeUnit.MILLISECONDS, new SynchronousQueue<Runnable>(),
+            new BackendThreadFactory("kie-subscribe-long-task"));
+
+    /**
+     * 快速返回的请求
+     */
+    private ScheduledExecutorService scheduledExecutorService;
+
+    public SubscriberManager(String urls) {
+        kieClient = new KieClient(new ClientUrlManager(urls));
+    }
+
+    /**
+     * 添加组监听
+     *
+     * @param group 标签组
+     * @param listener 监听器
+     * @return 是否添加成功
+     */
+    public boolean addGroupListener(String group, ConfigurationListener listener) {
+        if (!LabelGroupUtils.isLabelGroup(group)) {
+            // 如果非group标签（ZK配置中心场景适配），则为该group创建标签
+            group = LabelGroupUtils.createLabelGroup(Collections.singletonMap("GROUP", group));
+        }
+        try {
+            return subscribe(new KieRequest().setLabelCondition(LabelGroupUtils.getLabelCondition(group)).setWait(WAIT), listener);
+        } catch (Exception ex) {
+            LOGGER.warn(String.format(Locale.ENGLISH, "Add group listener failed, %s", ex.getMessage()));
+            return false;
+        }
+    }
+
+    /**
+     * 移除组监听
+     *
+     * @param group 标签组
+     * @param listener 监听器
+     * @return 是否添加成功
+     */
+    public boolean removeGroupListener(String group, ConfigurationListener listener) {
+        try {
+            return unSubscribe(new KieRequest().setLabelCondition(LabelGroupUtils.getLabelCondition(group)).setWait(WAIT), listener);
+        } catch (Exception ex) {
+            LOGGER.warn(String.format(Locale.ENGLISH, "Removed group listener failed, %s", ex.getMessage()));
+            return false;
+        }
+    }
+
+    /**
+     * 发布配置
+     *
+     * @param key 配置键
+     * @param group 分组
+     * @param content 配置内容
+     * @return 是否发布成功
+     */
+    public boolean publishConfig(String key, String group, String content) {
+        if (StringUtils.isEmpty(key)) {
+            return false;
+        }
+        final Map<String, String> labels = LabelGroupUtils.resolveGroupLabels(group);
+        return kieClient.publishConfig(key, labels, content, true);
+    }
+
+    /**
+     * 注册监听器
+     *
+     * @param kieRequest            请求
+     * @param configurationListener 监听器
+     */
+    public boolean subscribe(KieRequest kieRequest, ConfigurationListener configurationListener) {
+        final KieSubscriber kieSubscriber = new KieSubscriber(kieRequest);
+        Task task;
+        KieListenerWrapper kieListenerWrapper = new KieListenerWrapper(kieRequest.getLabelCondition(), configurationListener, new KvDataHolder());
+        if (!kieSubscriber.isLongConnectionRequest()) {
+            task = new ShortTimerTask(kieSubscriber, kieListenerWrapper);
+        } else {
+            if (exceedMaxLongRequestCount()) {
+                LOGGER.warn(String.format(Locale.ENGLISH,
+                        "Exceeded max long connection request subscribers, the max number is %s, it will be discarded!",
+                        curLongConnectionRequestCount.get()));
+                return false;
+            }
+            buildRequestConfig(kieRequest);
+            task = new LoopPullTask(kieSubscriber, kieListenerWrapper);
+            firstRequest(kieRequest, kieListenerWrapper);
+        }
+        List<KieListenerWrapper> configurationListeners = listenerMap.get(kieSubscriber);
+        if (configurationListeners == null) {
+            configurationListeners = new ArrayList<KieListenerWrapper>();
+        }
+        kieListenerWrapper.setTask(task);
+        configurationListeners.add(kieListenerWrapper);
+        listenerMap.put(kieSubscriber, configurationListeners);
+        executeTask(task);
+        return true;
+    }
+
+    /**
+     * 是否超过最大限制长连接任务数
+     *
+     * @return boolean
+     */
+    private boolean exceedMaxLongRequestCount() {
+        return curLongConnectionRequestCount.incrementAndGet() > MAX_THREAD_SIZE;
+    }
+
+    /**
+     * 针对长请求的场景需要做第一次拉取，获取已有的数据
+     *
+     * @param kieRequest         请求体
+     * @param kieListenerWrapper 监听器
+     */
+    public void firstRequest(KieRequest kieRequest, KieListenerWrapper kieListenerWrapper) {
+        try {
+            final KieRequest cloneRequest = new KieRequest().setRevision(kieRequest.getRevision())
+                    .setLabelCondition(kieRequest.getLabelCondition());
+            final KieResponse kieResponse = kieClient.queryConfigurations(cloneRequest);
+            if (kieResponse != null && kieResponse.isChanged()) {
+                tryPublishEvent(kieResponse, kieListenerWrapper);
+                kieRequest.setRevision(kieResponse.getRevision());
+            }
+        } catch (Exception ex) {
+            LOGGER.warn(String.format(Locale.ENGLISH, "Pull the first request failed! %s", ex.getMessage()));
+        }
+    }
+
+    /**
+     * 取消订阅
+     *
+     * @param kieRequest 请求体
+     */
+    public boolean unSubscribe(KieRequest kieRequest, ConfigurationListener configurationListener) {
+        for (Map.Entry<KieSubscriber, List<KieListenerWrapper>> next : listenerMap.entrySet()) {
+            if (!next.getKey().getKieRequest().equals(kieRequest)) {
+                continue;
+            }
+            final Iterator<KieListenerWrapper> iterator = next.getValue().iterator();
+            while (iterator.hasNext()) {
+                final KieListenerWrapper listenerWrapper = iterator.next();
+                if (listenerWrapper.getConfigurationListener() == configurationListener) {
+                    iterator.remove();
+                    listenerWrapper.getTask().stop();
+                    LOGGER.info(String.format(Locale.ENGLISH, "%s has been stopped!",
+                            configurationListener.getClass().getName()));
+                    return true;
+                }
+            }
+        }
+        LOGGER.warn(String.format(Locale.ENGLISH, "The subscriber of group %s not found!",
+                kieRequest.getLabelCondition()));
+        return false;
+    }
+
+    private void buildRequestConfig(KieRequest kieRequest) {
+        int wait = (Integer.parseInt(kieRequest.getWait()) + 1) * SECONDS_UNIT;
+        if (kieRequest.getRequestConfig() == null) {
+            kieRequest.setRequestConfig(RequestConfig.custom()
+                    .setConnectionRequestTimeout(wait)
+                    .setConnectTimeout(wait)
+                    .setSocketTimeout(wait)
+                    .build());
+        }
+    }
+
+    private void executeTask(final Task task) {
+        try {
+            if (task.isLongConnectionRequest()) {
+                longRequestExecutor.execute(new TaskRunnable(task));
+            } else {
+                if (scheduledExecutorService == null) {
+                    synchronized (SubscriberManager.class) {
+                        if (scheduledExecutorService == null) {
+                            scheduledExecutorService = new ScheduledThreadPoolExecutor(THREAD_SIZE,
+                                    new BackendThreadFactory("kie-subscribe-task"));
+                        }
+                    }
+                }
+                scheduledExecutorService.scheduleAtFixedRate(
+                        new TaskRunnable(task), 0, SCHEDULE_REQUEST_INTERVAL_MS, TimeUnit.MILLISECONDS);
+            }
+        } catch (RejectedExecutionException ex) {
+            LOGGER.warn("Rejected the task " + task.getClass() + " " + ex.getMessage());
+        }
+    }
+
+    private void tryPublishEvent(KieResponse kieResponse, KieListenerWrapper kieListenerWrapper) {
+        final KvDataHolder kvDataHolder = kieListenerWrapper.getKvDataHolder();
+        final KvDataHolder.EventDataHolder eventDataHolder = kvDataHolder.analyzeLatestData(kieResponse);
+        if (eventDataHolder.isChanged()) {
+            kieListenerWrapper.notifyListener(eventDataHolder);
+        }
+    }
+
+    static class TaskRunnable implements Runnable {
+        private final Task task;
+
+        TaskRunnable(Task task) {
+            this.task = task;
+        }
+
+        @Override
+        public void run() {
+            try {
+                task.execute();
+            } catch (Exception ex) {
+                LOGGER.warn(String.format(Locale.ENGLISH, "The error occurred when execute task , %s", ex.getMessage()));
+            }
+        }
+    }
+
+    public interface Task {
+
+        /**
+         * 任务执行
+         */
+        void execute();
+
+        /**
+         * 是否为长时间保持连接的请求
+         *
+         * @return boolean
+         */
+        boolean isLongConnectionRequest();
+
+        /**
+         * 任务终止
+         */
+        void stop();
+    }
+
+    abstract static class AbstractTask implements Task {
+        protected volatile boolean isContinue = true;
+
+        @Override
+        public void execute() {
+            if (!isContinue) {
+                return;
+            }
+            executeInner();
+        }
+
+        @Override
+        public void stop() {
+            isContinue = false;
+        }
+
+        /**
+         * 子类执行方法
+         */
+        public abstract void executeInner();
+    }
+
+    /**
+     * 定时短期任务
+     */
+    class ShortTimerTask extends AbstractTask {
+
+        private final KieSubscriber kieSubscriber;
+
+        private final KieListenerWrapper kieListenerWrapper;
+
+        ShortTimerTask(KieSubscriber kieSubscriber, KieListenerWrapper kieListenerWrapper) {
+            this.kieSubscriber = kieSubscriber;
+            this.kieListenerWrapper = kieListenerWrapper;
+        }
+
+        @Override
+        public void executeInner() {
+            final KieResponse kieResponse = kieClient.queryConfigurations(kieSubscriber.getKieRequest());
+            if (kieResponse != null && kieResponse.isChanged()) {
+                tryPublishEvent(kieResponse, kieListenerWrapper);
+                kieSubscriber.getKieRequest().setRevision(kieResponse.getRevision());
+            }
+        }
+
+        @Override
+        public boolean isLongConnectionRequest() {
+            return false;
+        }
+    }
+
+    class LoopPullTask extends AbstractTask {
+        private final KieSubscriber kieSubscriber;
+
+        private final KieListenerWrapper kieListenerWrapper;
+
+        private int failCount;
+
+        LoopPullTask(KieSubscriber kieSubscriber, KieListenerWrapper kieListenerWrapper) {
+            this.kieSubscriber = kieSubscriber;
+            this.kieListenerWrapper = kieListenerWrapper;
+        }
+
+        @Override
+        public void executeInner() {
+            try {
+                final KieResponse kieResponse = kieClient.queryConfigurations(kieSubscriber.getKieRequest());
+                if (kieResponse != null && kieResponse.isChanged()) {
+                    tryPublishEvent(kieResponse, kieListenerWrapper);
+                    kieSubscriber.getKieRequest().setRevision(kieResponse.getRevision());
+                }
+                // 间隔一段时间拉取，减轻服务压力;
+                // 如果在间隔时间段内有键变更，服务可以通过传入的revision判断是否需要将最新的数据立刻返回，不会存在键监听不到的问题
+                this.failCount = 0;
+                SubscriberManager.this.executeTask(new SleepCallBackTask(this, LONG_CONNECTION_REQUEST_INTERVAL_MS));
+            } catch (Exception ex) {
+                LOGGER.warn(String.format(Locale.ENGLISH, "pull kie config failed, %s, it will rePull", ex.getMessage()));
+                ++failCount;
+                SubscriberManager.this.executeTask(new SleepCallBackTask(this, failCount));
+            }
+        }
+
+        @Override
+        public boolean isLongConnectionRequest() {
+            return kieSubscriber.isLongConnectionRequest();
+        }
+    }
+
+    class SleepCallBackTask extends AbstractTask {
+        private final Task nextTask;
+
+        private int failedCount;
+
+        private long waitTimeMs;
+
+        public SleepCallBackTask(Task nextTask, int failedCount) {
+            this.nextTask = nextTask;
+            this.failedCount = failedCount;
+        }
+
+        public SleepCallBackTask(Task nextTask, long waitTimeMs) {
+            this.nextTask = nextTask;
+            this.waitTimeMs = waitTimeMs;
+        }
+
+        @Override
+        public void executeInner() {
+            long maxWaitMs = 60 * 1000 * 60;
+            long wait;
+            if (waitTimeMs != 0) {
+                wait = Math.min(waitTimeMs, maxWaitMs);
+            } else {
+                long baseMs = 3000;
+                wait = Math.min(maxWaitMs, baseMs * failedCount * failedCount);
+            }
+            try {
+                Thread.sleep(wait);
+                SubscriberManager.this.executeTask(nextTask);
+            } catch (InterruptedException ignored) {
+                // ignored
+            }
+        }
+
+        @Override
+        public boolean isLongConnectionRequest() {
+            return nextTask.isLongConnectionRequest();
+        }
+
+        @Override
+        public void stop() {
+            nextTask.stop();
+        }
+    }
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/selector/SelectStrategy.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/selector/SelectStrategy.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.kie.selector;
+
+import java.util.List;
+import java.util.Random;
+
+/**
+ * 选择策略
+ *
+ * @author zhouss
+ * @since 2021-11-17
+ */
+public interface SelectStrategy<R> {
+
+    /**
+     * 选择
+     *
+     * @param list 目标集合
+     * @return 确定的目标
+     */
+    R select(List<R> list);
+
+    /**
+     * 轮询策略
+     *
+     * @param <R> 集合类型
+     */
+    class RoundStrategy<R> implements SelectStrategy<R> {
+        private int index = 0;
+
+        @Override
+        public R select(List<R> list) {
+            if (list == null || list.isEmpty()) {
+                return null;
+            }
+            index++;
+            int selectIndex = Math.abs(index) % list.size();
+            if (index == Integer.MAX_VALUE) {
+                index = 0;
+            }
+            return list.get(selectIndex);
+        }
+    }
+
+    /**
+     * 随机选择策略
+     *
+     * @param <R> 集合类型
+     */
+    class RandomStrategy<R> implements SelectStrategy<R> {
+        private final Random random = new Random();
+        @Override
+        public R select(List<R> list) {
+            if (list == null || list.isEmpty()) {
+                return null;
+            }
+            return list.get(random.nextInt(list.size()));
+        }
+    }
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/selector/Selector.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/selector/Selector.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.kie.selector;
+
+import java.util.List;
+
+/**
+ * 选择器
+ *
+ * @author zhouss
+ * @since 2021-11-17
+ */
+public interface Selector<R> {
+    /**
+     * 选择
+     *
+     * @param list 目标集合
+     * @return 确定的目标
+     */
+    R select(List<R> list);
+
+    /**
+     * 选择
+     *
+     * @param strategy 选择策略
+     * @param list 目标集合
+     * @return 确定的目标
+     */
+    R select(List<R> list, SelectStrategy<R> strategy);
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/selector/url/UrlSelector.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/selector/url/UrlSelector.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.kie.selector.url;
+
+import com.huawei.javamesh.backend.service.dynamicconfig.kie.selector.SelectStrategy;
+import com.huawei.javamesh.backend.service.dynamicconfig.kie.selector.Selector;
+
+import java.util.List;
+
+/**
+ * url
+ *
+ * @author zhouss
+ * @since 2021-11-17
+ */
+public class UrlSelector implements Selector<String> {
+
+    private final SelectStrategy<String> defaultStrategy = new SelectStrategy.RoundStrategy<String>();
+
+    @Override
+    public String select(List<String> list) {
+        return defaultStrategy.select(list);
+    }
+
+    @Override
+    public String select(List<String> list, SelectStrategy<String> strategy) {
+        return strategy.select(list);
+    }
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/nop/NopDynamicConfigurationService.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/nop/NopDynamicConfigurationService.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.nop;
+
+import com.huawei.javamesh.backend.service.dynamicconfig.Config;
+import com.huawei.javamesh.backend.service.dynamicconfig.service.ConfigurationListener;
+import com.huawei.javamesh.backend.service.dynamicconfig.service.DynamicConfigurationService;
+
+/**
+ *   This class is for testing purpose only.
+ */
+@Deprecated
+public class NopDynamicConfigurationService implements DynamicConfigurationService {
+    static private NopDynamicConfigurationService serviceInst;
+
+    private NopDynamicConfigurationService() {
+        // no-op
+    }
+
+    public static synchronized NopDynamicConfigurationService getInstance()
+    {
+        if ( serviceInst == null )
+        {
+            serviceInst = new NopDynamicConfigurationService();
+        }
+        return serviceInst;
+    }
+
+
+    @Override
+    public boolean addConfigListener(String key, String group, ConfigurationListener listener) {
+        return true;
+    }
+
+    @Override
+    public boolean removeConfigListener(String key, String group, ConfigurationListener listener) {
+        return true;
+    }
+
+    @Override
+    public String getConfig(String key, String group) throws IllegalStateException {
+        // no-op
+        return "";
+    }
+
+    /**
+     * @since 2.7.5
+     */
+    @Override
+    public boolean publishConfig(String key, String group, String content) {
+        return true;
+    }
+
+    @Override
+    public String getDefaultGroup() {
+        return Config.getDefaultGroup();
+    }
+
+    @Override
+    public long getDefaultTimeout() {
+        return Config.getTimeout_value();
+    }
+
+    @Override
+    public void close() throws Exception {
+        // no-op
+    }
+
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/service/ConfigChangeType.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/service/ConfigChangeType.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.service;
+
+/**
+ * Config change event type
+ */
+public enum ConfigChangeType {
+    /**
+     * A config is created.
+     */
+    ADDED,
+
+    /**
+     * A config is updated.
+     */
+    MODIFIED,
+
+    /**
+     * A config is deleted.
+     */
+    DELETED
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/service/ConfigChangedEvent.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/service/ConfigChangedEvent.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.service;
+
+import java.util.EventObject;
+import java.util.Objects;
+
+/**
+ * An event raised when the config changed, immutable.
+ *
+ * @see ConfigChangeType
+ */
+public class ConfigChangedEvent extends EventObject {
+
+    private final String key;
+
+    private final String group;
+
+    private final String content;
+
+    private final ConfigChangeType changeType;
+
+    public ConfigChangedEvent(String key, String group, String content) {
+        this(key, group, content, ConfigChangeType.MODIFIED);
+    }
+
+    public ConfigChangedEvent(String key, String group, String content, ConfigChangeType changeType) {
+        super(key + "," + group);
+        this.key = key;
+        this.group = group;
+        this.content = content;
+        this.changeType = changeType;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public ConfigChangeType getChangeType() {
+        return changeType;
+    }
+
+    @Override
+    public String toString() {
+        return "ConfigChangedEvent{" +
+                "key='" + key + '\'' +
+                ", group='" + group + '\'' +
+                ", content='" + content + '\'' +
+                ", changeType=" + changeType +
+                "} " + super.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ConfigChangedEvent)) {
+            return false;
+        }
+        ConfigChangedEvent that = (ConfigChangedEvent) o;
+        return Objects.equals(getKey(), that.getKey()) &&
+                Objects.equals(getGroup(), that.getGroup()) &&
+                Objects.equals(getContent(), that.getContent()) &&
+                getChangeType() == that.getChangeType();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getKey(), getGroup(), getContent(), getChangeType());
+    }
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/service/ConfigurationListener.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/service/ConfigurationListener.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.service;
+
+import java.util.EventListener;
+
+/**
+ * Config listener, will get notified when the config it listens on changes.
+ */
+public interface ConfigurationListener extends EventListener {
+
+    /**
+     * Listener call back method. Listener gets notified by this method once there's any change happens on the config
+     * the listener listens on.
+     *
+     * @param event config change event
+     */
+    void process(ConfigChangedEvent event);
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/service/DynamicConfigType.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/service/DynamicConfigType.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.service;
+
+
+/**
+ *
+ * Enum for DynamicConfigType,
+ * Currently support ZooKeeper, Kie, Nop.
+ * Probably will support Nacos, etcd in the future.
+ *
+ */
+public enum DynamicConfigType {
+
+    /**
+     * zookeeper 配置中心
+     */
+    ZOO_KEEPER,
+
+    /**
+     * servicecomb-kie 配置中心
+     */
+    KIE,
+
+    /**
+     * 配置中心无实现
+     */
+    NOP;
+
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/service/DynamicConfigurationFactoryService.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/service/DynamicConfigurationFactoryService.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.service;
+
+/**
+ *
+ * Core service for the dynamic config service.
+ * This factory is used to retrieve the default configuration service.
+ *
+ */
+public interface DynamicConfigurationFactoryService {
+
+    public DynamicConfigurationService getDynamicConfigurationService();
+
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/service/DynamicConfigurationService.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/service/DynamicConfigurationService.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.service;
+
+import java.util.List;
+
+public interface DynamicConfigurationService extends AutoCloseable {
+
+    default boolean addConfigListener(String key, ConfigurationListener listener) {
+        return addConfigListener(key, getDefaultGroup(), listener);
+    }
+
+    default boolean addGroupListener(String Group, ConfigurationListener listener) {
+        throw new UnsupportedOperationException();
+    }
+
+
+    default boolean removeConfigListener(String key, ConfigurationListener listener) {
+        return removeConfigListener(key, getDefaultGroup(), listener);
+    }
+
+    default boolean removeGroupListener(String key, String group, ConfigurationListener listener) {
+        throw new UnsupportedOperationException();
+    }
+
+    boolean addConfigListener(String key, String group, ConfigurationListener listener);
+
+    boolean removeConfigListener(String key, String group, ConfigurationListener listener);
+
+
+
+
+    String getConfig(String key, String group);
+
+
+    default String getConfig(String key)
+    {
+        return getConfig(key, getDefaultGroup());
+    }
+
+
+    default boolean publishConfig(String key, String content) {
+        return publishConfig(key, getDefaultGroup(), content);
+    }
+
+
+    boolean publishConfig(String key, String group, String content) ;
+
+
+    String getDefaultGroup();
+
+
+    long getDefaultTimeout();
+
+
+    @Override
+    default void close() throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+
+    default boolean removeConfig(String key, String group) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+    default List<String> listConfigsFromGroup(String group) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+    default List<String> listConfigsFromConfig(String key) throws Exception {
+        return listConfigsFromConfig(key, getDefaultGroup());
+    }
+
+    default List<String> listConfigsFromConfig(String key, String group) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/utils/LabelGroupUtils.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/utils/LabelGroupUtils.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.utils;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * group生成工具
+ *
+ * @author zhouss
+ * @since 2021-11-23
+ */
+public class LabelGroupUtils {
+    private static final Logger LOGGER = LoggerFactory.getLogger(LabelGroupUtils.class);
+
+    private static final String GROUP_SEPARATOR = "&";
+
+    private static final String KV_SEPARATOR = "=";
+
+    /**
+     * 查询时使用的kv分隔符
+     */
+    private static final String LABEL_QUERY_SEPARATOR = ":";
+
+    /**
+     * 查询标签前缀
+     */
+    private static final String LABEL_PREFIX = "label=";
+
+    private LabelGroupUtils() {
+    }
+
+    /**
+     * 创建标签组
+     *
+     * @param labels 标签组
+     * @return labelGroup 例如: app=sc&service=helloService
+     */
+    public static String createLabelGroup(Map<String, String> labels) {
+        if (labels == null || labels.isEmpty()) {
+            return StringUtils.EMPTY;
+        }
+        final StringBuilder group = new StringBuilder();
+        for (Map.Entry<String, String> entry : labels.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            if (key == null || value == null) {
+                LOGGER.warn(String.format(Locale.ENGLISH, "Invalid group label, key = %s, value = %s",
+                        key, value));
+                continue;
+            }
+            group.append(key).append(KV_SEPARATOR).append(value).append(GROUP_SEPARATOR);
+        }
+        if (group.length() == 0) {
+            return StringUtils.EMPTY;
+        }
+        return group.deleteCharAt(group.length() - 1).toString();
+    }
+
+    /**
+     * 是否为标签组key
+     *
+     * @param group 监听键
+     * @return 是否为标签组
+     */
+    public static boolean isLabelGroup(String group) {
+        return group != null && group.contains(KV_SEPARATOR);
+    }
+
+    /**
+     * 解析标签为map
+     *
+     * @param group 标签组  app=sc&service=helloService
+     * @return 标签键值对
+     */
+    public static Map<String, String> resolveGroupLabels(String group) {
+        final Map<String, String> result = new HashMap<>();
+        if (group == null) {
+            return result;
+        }
+        if (!isLabelGroup(group)) {
+            return result;
+        }
+        try {
+            final String decode = URLDecoder.decode(group, "UTF-8");
+            final String[] labels = decode.split("&");
+            for (String label : labels) {
+                final String[] labelKv = label.split("=");
+                if (labelKv.length != 2) {
+                    continue;
+                }
+                result.put(labelKv[0], labelKv[1]);
+            }
+        } catch (UnsupportedEncodingException ignored) {
+            // ignored
+        }
+        return result;
+    }
+
+    /**
+     * 获取标签信息
+     *
+     * @param group 分组  app=sc&service=helloService转换label=app:sc&label=service:helloService
+     * @return 标签组条件
+     */
+    public static String getLabelCondition(String group) {
+        if (StringUtils.isEmpty(group)) {
+            return group;
+        }
+        final Map<String, String> labels = resolveGroupLabels(group);
+        final StringBuilder finalGroup = new StringBuilder();
+        for (Map.Entry<String, String> entry : labels.entrySet()) {
+            finalGroup.append(LABEL_PREFIX)
+                    .append(buildSingleLabel(entry.getKey(), entry.getValue()))
+                    .append(GROUP_SEPARATOR);
+        }
+        return finalGroup.deleteCharAt(finalGroup.length() - 1).toString();
+    }
+
+    private static String buildSingleLabel(String key, String value) {
+        try {
+            return URLEncoder.encode(key + LABEL_QUERY_SEPARATOR + value, "UTF-8");
+        } catch (UnsupportedEncodingException ignored) {
+            // ignored
+        }
+        return StringUtils.EMPTY;
+    }
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/zookeeper/ZookeeperDynamicConfigurationService.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/zookeeper/ZookeeperDynamicConfigurationService.java
@@ -1,0 +1,402 @@
+/*
+ * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.service.dynamicconfig.zookeeper;
+
+import com.huawei.javamesh.backend.service.dynamicconfig.Config;
+import com.huawei.javamesh.backend.service.dynamicconfig.service.ConfigChangeType;
+import com.huawei.javamesh.backend.service.dynamicconfig.service.ConfigChangedEvent;
+import com.huawei.javamesh.backend.service.dynamicconfig.service.ConfigurationListener;
+import com.huawei.javamesh.backend.service.dynamicconfig.service.DynamicConfigurationService;
+import com.huawei.javamesh.backend.service.dynamicconfig.utils.LabelGroupUtils;
+import org.apache.zookeeper.AddWatchMode;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Vector;
+
+/**
+ * Zookeeper implementation for DynamicConfigurationService
+ */
+public class ZookeeperDynamicConfigurationService implements DynamicConfigurationService {
+
+    private static final Logger logger = LoggerFactory.getLogger(ZookeeperDynamicConfigurationService.class);
+
+    ZooKeeper zkClient;
+
+    static private ZookeeperDynamicConfigurationService serviceInst;
+
+    private ZookeeperDynamicConfigurationService() {
+
+    }
+
+    @Override
+    public String getDefaultGroup() {
+        return Config.getDefaultGroup();
+    }
+
+    @Override
+    public long getDefaultTimeout() {
+        return Config.getTimeout_value();
+    }
+
+    public static synchronized ZookeeperDynamicConfigurationService getInstance() {
+        if (serviceInst == null) {
+            serviceInst = new ZookeeperDynamicConfigurationService();
+            URI zk_uri;
+
+            try {
+                zk_uri = new URI(Config.getZookeeperUri());
+            } catch (URISyntaxException e) {
+                logger.error(e.getMessage(), e);
+                throw new RuntimeException(e);
+            }
+
+            String zk_con_str = zk_uri.getHost();
+            if (zk_uri.getPort() > 0) {
+                zk_con_str = zk_con_str + ":" + zk_uri.getPort();
+            }
+
+            ZooKeeper zkInst;
+            try {
+                zkInst = new ZooKeeper(zk_con_str, Config.getTimeout_value(), new Watcher() {
+                    @Override
+                    public void process(WatchedEvent event) {
+                    }
+                });
+            } catch (IOException e) {
+                logger.error(e.getMessage(), e);
+                throw new RuntimeException(e);
+            }
+
+            serviceInst.zkClient = zkInst;
+        }
+
+        return serviceInst;
+    }
+
+    private String getPath(String key, String group) {
+        group = fixGroup(group);
+        return group.startsWith("/") ? group + key : '/' + group + key;
+    }
+
+    private String fixGroup(String group) {
+        return group == null ? getDefaultGroup() : group;
+    }
+
+    private ConfigChangeType transEventType(Watcher.Event.EventType type) {
+        switch (type) {
+            case NodeCreated:
+                return ConfigChangeType.ADDED;
+            case NodeDeleted:
+                return ConfigChangeType.DELETED;
+            case None:
+            case NodeDataChanged:
+            case DataWatchRemoved:
+            case ChildWatchRemoved:
+            case NodeChildrenChanged:
+            case PersistentWatchRemoved:
+            default:
+                return ConfigChangeType.MODIFIED;
+        }
+    }
+
+    /**
+     * 添加组监听
+     * 若由Kie配置中心转换而来，则配置路径为<h4>/group/key</h4>
+     * <pre>
+     * 其中:
+     * group: 由{@link LabelGroupUtils#createLabelGroup(Map)}生成
+     * key: 则是对应kie的键名
+     * </pre>
+     * <p>第一次添加会将group下的所有子路径的数据通知给监听器</p>
+     *
+     * @param group    分组
+     * @param listener 监听器
+     * @return boolean
+     */
+    @Override
+    public boolean addGroupListener(String group, ConfigurationListener listener) {
+        try {
+            if (listener == null) {
+                return false;
+            }
+            // 监听group底下所有的子节点数据变更
+            final String path = getPath("", fixGroup(group));
+            zkClient.addWatch(path, new Watcher() {
+                @Override
+                public void process(WatchedEvent event) {
+                    if (event.getPath() == null || event.getPath().equals(path)
+                            || !event.getPath().startsWith(path)) {
+                        return;
+                    }
+                    // 带有分隔符"/"的键
+                    String keyWithSeparator = event.getPath().substring(group.length() + 1);
+                    if (keyWithSeparator.length() < 1) {
+                        return;
+                    }
+                    final String content = getConfig(keyWithSeparator, group);
+                    listener.process(new ConfigChangedEvent(keyWithSeparator.substring(1), group, content,
+                            transEventType(event.getType())));
+                }
+            }, AddWatchMode.PERSISTENT_RECURSIVE);
+            notifyGroup(group, listener);
+        } catch (KeeperException.NoNodeException ignored) {
+            // ignored
+        } catch (Exception e) {
+            logger.warn(
+                    String.format(Locale.ENGLISH, "Added zookeeper group listener failed, %s", e.getMessage()), e);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean removeGroupListener(String key, String group, ConfigurationListener listener) {
+        return true;
+    }
+
+    /**
+     * 添加zookeeper路径监听
+     * 将会监听路径<code>/group/key</code>的数据变更
+     * <h3>一次添加将会将节点数据通知给监听器</h3>
+     *
+     * @param key 子路径
+     * @param group 父路径
+     * @param listener 监听器
+     * @return 当连接zk失败返回false
+     */
+    @Override
+    public boolean addConfigListener(String key, String group, ConfigurationListener listener) {
+
+        if (listener == null)
+            return false;
+
+        final String finalGroup = fixGroup(group);
+        final String fullPath = getPath(key, finalGroup);
+        Watcher wc = new Watcher() {
+            @Override
+            public void process(WatchedEvent event) {
+                if (!fullPath.equals(event.getPath()))
+                    logger.warn("unexpected event " + event + " for " + key + ":" + finalGroup);
+                String content = getConfig(key, finalGroup);
+                ConfigChangeType changeType = transEventType(event.getType());
+                ConfigChangedEvent cce = new ConfigChangedEvent(key, finalGroup, content, changeType);
+                listener.process(cce);
+            }
+        };
+
+        try {
+            zkClient.addWatch(fullPath, wc, AddWatchMode.PERSISTENT);
+            notifyKey(key, group, listener);
+        } catch (KeeperException.NoNodeException ignored) {
+            // ignored
+        } catch (Exception e) {
+            logger.warn(e.getMessage(), e);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @param key      postfix of key path
+     * @param group    prefix of key path
+     * @param listener configuration listener
+     */
+    @Override
+    public boolean removeConfigListener(String key, String group, ConfigurationListener listener) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @param key key path
+     */
+    @Override
+    public String getConfig(String key, String group) {
+
+        final String fullPath = getPath(key, group);
+
+        String rs = null;
+        try {
+            Stat st = new Stat();
+            rs = new String(zkClient.getData(fullPath, false, st));
+        } catch (Exception e) {
+            logger.warn(e.getMessage(), e);
+            return null;
+        }
+        return rs;
+    }
+
+
+    @Override
+    public boolean publishConfig(String key, String group, String content) {
+
+        final String fullPath = getPath(key, group);
+
+        boolean rs = false;
+        try {
+            rs = this.updateNode(fullPath, content.getBytes(StandardCharsets.UTF_8), -1);
+        } catch (Exception e) {
+            logger.warn(e.getMessage(), e);
+            return false;
+        }
+        return rs;
+    }
+
+
+    protected boolean createRecursivly(String path) {
+        try {
+            if (zkClient.exists(path, null) == null && path.length() > 0) {
+                String temp = path.substring(0, path.lastIndexOf("/"));
+                if (temp != null && temp.length() > 1) {
+                    createRecursivly(temp);
+                }
+                zkClient.create(path, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            } else {
+
+            }
+        } catch (KeeperException e) {
+            logger.warn(e.getMessage(), e);
+            return false;
+        } catch (InterruptedException e) {
+            logger.warn(e.getMessage(), e);
+            return false;
+        }
+        return true;
+
+    }
+
+    protected boolean updateNode(String path, byte[] data, int version) {
+        try {
+            if (zkClient.exists(path, null) == null) {
+                createRecursivly(path);
+            }
+            zkClient.setData(path, data, version);
+        } catch (KeeperException e) {
+            logger.warn(e.getMessage(), e);
+            return false;
+        } catch (InterruptedException e) {
+            logger.warn(e.getMessage(), e);
+            return false;
+        }
+        return true;
+
+    }
+
+    @Override
+    public void close() {
+        try {
+            this.zkClient.close();
+        } catch (InterruptedException e) {
+            logger.error(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public List<String> listConfigsFromGroup(String group) {
+        group = group.trim();
+        if (group.startsWith("/") == false) {
+            group = "/" + group;
+        }
+        List<String> str_array = null;
+        try {
+            str_array = listNodesFromNode(group);
+        } catch (Exception e) {
+            logger.warn(e.getMessage(), e);
+        }
+        return str_array;
+    }
+
+    @Override
+    public List<String> listConfigsFromConfig(String key, String group) {
+        group = group.trim();
+        if (group.startsWith("/") == false) {
+            group = "/" + group;
+        }
+        key = key.trim();
+        if (key.startsWith("/") == false) {
+            key = "/" + key;
+        }
+
+        List<String> str_array = null;
+        try {
+            str_array = listNodesFromNode(group + key);
+        } catch (Exception e) {
+            logger.warn(e.getMessage(), e);
+        }
+        return str_array;
+    }
+
+    private List<String> listNodesFromNode(String node) {
+        List<String> str_array = new Vector<String>();
+        try {
+            if (zkClient.exists(node, false) != null) {
+                str_array = zkClient.getChildren(node, null);
+            }
+        } catch (Exception e) {
+            logger.warn(e.getMessage(), e);
+        }
+        for (int i = 0; i < str_array.size(); i++) {
+            String str = str_array.get(i);
+            for (String grandChild : listNodesFromNode(node + "/" + str)) {
+                str_array.add(str + '/' + grandChild);
+            }
+        }
+
+        return str_array;
+    }
+
+    /**
+     * 第一次增加监听器时，将关联查询的数据传给listener
+     *
+     * @param group    分组
+     * @param listener 监听器
+     */
+    private void notifyGroup(String group, ConfigurationListener listener) {
+        final List<String> keys = listConfigsFromGroup(group);
+        if (keys != null) {
+            for (String key : keys) {
+                notifyKey(key, group, listener);
+            }
+        }
+    }
+
+    private void notifyKey(String key, String group, ConfigurationListener listener) {
+        final String content = getConfig(fixKey(key), group);
+        listener.process(new ConfigChangedEvent(key, group, content, ConfigChangeType.ADDED));
+    }
+
+    private String fixKey(String key) {
+        if (key == null) {
+            return null;
+        }
+        return key.startsWith("/") ? key : "/" + key;
+    }
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/util/BackendThreadFactory.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/util/BackendThreadFactory.java
@@ -1,0 +1,53 @@
+package com.huawei.javamesh.backend.util;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class BackendThreadFactory implements ThreadFactory {
+    private final static AtomicInteger FACTORY_NUMBER = new AtomicInteger(0);
+
+    private final AtomicInteger threadNumber = new AtomicInteger(0);
+
+    private final String threadPrefix;
+
+    private final boolean daemon;
+
+    public BackendThreadFactory() {
+        this("backend", true);
+    }
+
+    public BackendThreadFactory(String threadName) {
+        this(threadName, true);
+    }
+
+    public BackendThreadFactory(String threadName, boolean daemon) {
+        this.threadPrefix = prefix(threadName, FACTORY_NUMBER.getAndIncrement());
+        this.daemon = daemon;
+    }
+
+    public static ThreadFactory createThreadFactory(String threadName) {
+        return createThreadFactory(threadName, false);
+    }
+
+    public static ThreadFactory createThreadFactory(String threadName, boolean daemon) {
+        return new BackendThreadFactory(threadName, daemon);
+    }
+
+    private String prefix(String threadName, int factoryId) {
+        return threadName + '(' + factoryId + ')';
+    }
+
+    @Override
+    public Thread newThread(Runnable job) {
+        String newThreadName = createThreadName();
+        Thread thread = new Thread(job, newThreadName);
+        if (daemon) {
+            thread.setDaemon(true);
+        }
+        return thread;
+    }
+
+    private String createThreadName() {
+        return threadPrefix + threadNumber.getAndIncrement() + ')';
+    }
+}

--- a/javamesh-backend/src/main/resources/logback.xml
+++ b/javamesh-backend/src/main/resources/logback.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration scan="true">
+
+    <!-- 定义日志文件 输出位置 -->
+    <property name="log.home_dir" value="./backend_logs"/>
+    <property name="log.app_name" value="backend"/>
+    <!-- 日志最大的历史 30天 -->
+    <property name="log.maxHistory" value="30"/>
+    <property name="log.level" value="info"/>
+    <property name="log.maxSize" value="5MB" />
+
+    <!-- ConsoleAppender 控制台输出日志 -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>
+                <!-- 设置日志输出格式 -->
+                %d{yyyy-MM-dd HH:mm:ss.SSS} [%-5level] [%thread] %logger - %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <!--设置一个向上传递的appender,所有级别的日志都会输出-->
+    <appender name="app" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${log.home_dir}/app/%d{yyyy-MM-dd}/${log.app_name}-%i.log</fileNamePattern>
+            <maxHistory>${log.maxHistory}</maxHistory>
+            <MaxFileSize>${log.maxSize}</MaxFileSize>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5level] %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- root级别   DEBUG -->
+    <root>
+        <!-- 打印debug级别日志及以上级别日志 -->
+        <level value="${log.level}"/>
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="app" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
【issue号/问题单号/需求单号】#223

【修改内容】

- backend模块添加动态配置服务
- backend模块增加logback日志
- backend注册接口apm更改为sermant，core模块同步修改

【用例描述】暂无用例，门禁暂未提供zk等配置。

【自测情况】

- 本地测试通过
- 本地启动zk配置中心，通过postman调用增加配置接口。

【影响范围】

- 使用者可通过backend模块提供的接口修改配置中心配置
