### PR TITLE
backend增加修改配置接口

### DIFF
--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/PublishConfigEntity.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/PublishConfigEntity.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.huawei.javamesh.backend.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+import java.util.Map;
+
+@Getter
+@Setter
+public class PublishConfigEntity {
+
+    private String key;
+
+    private String content;
+
+    private Map<String, String> group;
+}

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/util/BackendThreadFactory.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/util/BackendThreadFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.huawei.javamesh.backend.util;
 
 import java.util.concurrent.ThreadFactory;


### PR DESCRIPTION
【issue号/问题单号/需求单号】#223

【修改内容】backend模块增加配置接口： POST /sermant/publishConfig

【用例描述】门禁暂未配置zk等环境。

【自测情况】

- 本地测试通过
- 本地启动zk配置中心，通过postman调用增加配置接口。

【影响范围】

- 使用者可通过backend模块提供的接口修改配置中心配置
