### PR TITLE
【doc】修正huawei copyright的时间与公司的顺序，与NOTICE文件保持一致

### DIFF
--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/AgentCoreEntrance.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/AgentCoreEntrance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/IgnoreClassMatcher.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/IgnoreClassMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/LoadListener.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/LoadListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/common/VersionChecker.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/common/VersionChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/definition/TopListener.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/definition/TopListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/enhancer/MemberFieldsHandler.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/enhancer/MemberFieldsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/interceptor/Interceptor.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/interceptor/Interceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/interceptor/InterceptorChain.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/interceptor/InterceptorChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/interceptor/InterceptorChainConfig.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/interceptor/InterceptorChainConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/interceptor/InterceptorChainManager.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/interceptor/InterceptorChainManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/template/BootstrapConstTemplate.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/template/BootstrapConstTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/template/BootstrapInstTemplate.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/template/BootstrapInstTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/template/BootstrapStaticTemplate.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/template/BootstrapStaticTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/transformer/BootstrapTransformer.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/transformer/BootstrapTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/transformer/CommonTransformer.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/transformer/CommonTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/transformer/MethodInterceptorCollector.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/agent/transformer/MethodInterceptorCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/common/BootArgsIndexer.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/common/BootArgsIndexer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/common/CommonConstant.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/common/CommonConstant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/common/LoggerFactory.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/common/LoggerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/config/ConfigManager.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/config/ConfigManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/config/common/BaseConfig.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/config/common/BaseConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/config/common/ConfigFieldKey.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/config/common/ConfigFieldKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/config/common/ConfigTypeKey.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/config/common/ConfigTypeKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/config/strategy/LoadConfigStrategy.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/config/strategy/LoadConfigStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/config/strategy/LoadPropertiesStrategy.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/config/strategy/LoadPropertiesStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/config/strategy/LoadYamlStrategy.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/config/strategy/LoadYamlStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/config/utils/ConfigFieldUtil.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/config/utils/ConfigFieldUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/config/utils/ConfigKeyUtil.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/config/utils/ConfigKeyUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/config/utils/ConfigValueUtil.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/config/utils/ConfigValueUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/exception/BizException.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/exception/BizException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/exception/DupConfIndexException.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/exception/DupConfIndexException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/exception/DupServiceManager.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/exception/DupServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/exception/EnhanceException.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/exception/EnhanceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/exception/IllegalConfigException.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/exception/IllegalConfigException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/exception/SchemaException.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/exception/SchemaException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/AttributeAccess.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/AttributeAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/Interceptor.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/Interceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/InterceptorManager.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/InterceptorManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/Listener.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/Listener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/NamedListener.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/NamedListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/NoneNamedListener.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/NoneNamedListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/TransformAccess.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/TransformAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/TransformerMethod.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/TransformerMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/agent/AgentInfo.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/agent/AgentInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/api/APIService.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/api/APIService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/api/AccessTransferConfigListener.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/api/AccessTransferConfigListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/api/CircuitBreaker.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/api/CircuitBreaker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/api/Container.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/api/Container.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/api/EventDispatcher.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/api/EventDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/api/HarvestListener.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/api/HarvestListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/api/InstrumentationManager.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/api/InstrumentationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/api/JSONAPI.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/api/JSONAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/api/SpanEventAccessor.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/api/SpanEventAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/api/TagListener.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/api/TagListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/CollectorManager.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/CollectorManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/MonitorItem.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/MonitorItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/UpdataListenerManager.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/UpdataListenerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/UpdateListener.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/UpdateListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/api/AbstractAggregator.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/api/AbstractAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/api/AbstractPrimaryKeyValueAggregator.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/api/AbstractPrimaryKeyValueAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/api/Collector.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/api/Collector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/api/FutureStatsAccessor.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/api/FutureStatsAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/api/MetricSet.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/api/MetricSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/api/MetricSetAggregator.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/api/MetricSetAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/api/MonitorDataRow.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/api/MonitorDataRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/api/MultiPrimaryKeyAggregator.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/api/MultiPrimaryKeyAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/api/NonePrimaryKeyAggregator.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/api/NonePrimaryKeyAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/api/PrimaryKey.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/api/PrimaryKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/api/SinglePrimaryKeyAggregator.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/api/SinglePrimaryKeyAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/api/StatsBase.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/api/StatsBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/interceptor/AggregatorAroundInterceptor.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/interceptor/AggregatorAroundInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/interceptor/AroundInterceptor.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/interceptor/AroundInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/interceptor/SQLAroundInterceptor.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/interceptor/SQLAroundInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/interceptor/StatsAroundInterceptor.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/collector/interceptor/StatsAroundInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/commons/AgentContext.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/commons/AgentContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/commons/ConditionOnVersion.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/commons/ConditionOnVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/commons/LubanApmConstants.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/commons/LubanApmConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/commons/ValidatorUtil.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/commons/ValidatorUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/config/AgentConfigManager.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/config/AgentConfigManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/config/ConfigManager.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/config/ConfigManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/config/IdentityConfigManager.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/config/IdentityConfigManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/config/Stats.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/config/Stats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/config/SysConfigKey.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/config/SysConfigKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/enums/EventType.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/enums/EventType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/enums/RunEnvironmentEnum.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/enums/RunEnvironmentEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/event/ApmEvent.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/event/ApmEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/event/SecureChangeEvent.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/event/SecureChangeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/exception/ApmRuntimeException.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/exception/ApmRuntimeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/holder/AgentServiceContainerHolder.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/holder/AgentServiceContainerHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/log/LogFactory.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/log/LogFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/log/LogPathUtils.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/log/LogPathUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/log/LoggerAdapter.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/log/LoggerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/apm/APMCollector.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/apm/APMCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/apm/APMStats.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/apm/APMStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/apm/DetailAggregator.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/apm/DetailAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/apm/ExceptionAggregator.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/apm/ExceptionAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/apm/ExceptionValue.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/apm/ExceptionValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/apm/RepositoryAggregator.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/apm/RepositoryAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/apm/TransferAggregator.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/apm/TransferAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/DefaultExceptionAggregator.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/DefaultExceptionAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/DefaultExceptionStats.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/DefaultExceptionStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/DefaultMutiVersionAggregator.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/DefaultMutiVersionAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/DefaultSectionStats.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/DefaultSectionStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/DefaultSinglePrimaryKeyAggregator.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/DefaultSinglePrimaryKeyAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/DefaultSqlSectionStats.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/DefaultSqlSectionStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/DefaultSqlStatsAggregator.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/DefaultSqlStatsAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/DefaultStats.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/DefaultStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/DefaultStatusCodeAggregator.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/DefaultStatusCodeAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/DefaultStatusCodeStats.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/DefaultStatusCodeStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/DefaultVersionAggregator.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/DefaultVersionAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/StatsStore.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/StatsStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/url/StatusCodeStats.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/url/StatusCodeStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/url/UrlAggregator.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/url/UrlAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/url/UrlOverallAggregator.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/url/UrlOverallAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/url/UrlSlowRequestThreshold.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/url/UrlSlowRequestThreshold.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/url/UrlStats.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/url/UrlStats.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/url/UrlStatusGroupAggregator.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/plugin/common/url/UrlStatusGroupAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/sample/SampleConfig.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/sample/SampleConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/sample/SampleType.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/sample/SampleType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/trace/ErrorType.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/trace/ErrorType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/trace/Headers.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/trace/Headers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/trace/SampleFilter.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/trace/SampleFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/trace/SpanEvent.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/trace/SpanEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/trace/SpanEventFilter.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/trace/SpanEventFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/trace/StartTraceRequest.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/trace/StartTraceRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/trace/Tags.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/trace/Tags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/trace/TraceCollector.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/trace/TraceCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/trace/TraceReportService.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/trace/TraceReportService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/transaction/MetricTransaction.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/transaction/MetricTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/transaction/Transaction.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/transaction/Transaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/transaction/TransactionManager.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/transaction/TransactionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/AgentUtils.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/AgentUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/AntPathMatcher.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/AntPathMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/AtomicDouble.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/AtomicDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/ConcurrentUtil.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/ConcurrentUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/DefaultNormalizedSql.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/DefaultNormalizedSql.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/DefaultSqlParser.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/DefaultSqlParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/ExceptionUtil.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/ExceptionUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/FileUtils.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/FileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/GZIPUtils.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/GZIPUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/HarvestUtil.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/HarvestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/InputSafetyChecker.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/InputSafetyChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/IntegerMap.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/IntegerMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/LogForgingUtil.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/LogForgingUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/NormalizedSql.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/NormalizedSql.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/ParamCheckUtils.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/ParamCheckUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/ParameterParseUtil.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/ParameterParseUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/PathMatcher.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/PathMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/SqlParser.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/SqlParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/SqlParserUtil.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/SqlParserUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/StringUtils.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/StringUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/ThreadUtils.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/ThreadUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/Util.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/bootstrap/utils/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/BootStrapImpl.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/BootStrapImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/api/AgentService.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/api/AgentService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/api/IntervalTaskManager.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/api/IntervalTaskManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/api/JSONImpl.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/api/JSONImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/common/ConcurrentHashSet.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/common/ConcurrentHashSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/common/ConnectionException.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/common/ConnectionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/common/CountDownLatch2.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/common/CountDownLatch2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/common/NamedThreadFactory.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/common/NamedThreadFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/config/StartupConfigManager.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/config/StartupConfigManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/container/AgentServiceContainer.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/container/AgentServiceContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/container/Priority.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/container/Priority.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/container/PriorityComparator.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/container/PriorityComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/container/module/AbstractAgentModule.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/container/module/AbstractAgentModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/container/module/AgentServiceModule.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/container/module/AgentServiceModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/enums/ConfigType.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/enums/ConfigType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/event/ApmEventDispatcher.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/event/ApmEventDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/executor/ExecuteRepository.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/executor/ExecuteRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/executor/manager/DefaultExecuteRepository.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/executor/manager/DefaultExecuteRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/executor/standalone/ServiceThread.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/executor/standalone/ServiceThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/executor/timer/AbstractTimerTask.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/executor/timer/AbstractTimerTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/executor/timer/HashedWheelTimer.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/executor/timer/HashedWheelTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/executor/timer/Timeout.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/executor/timer/Timeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/executor/timer/Timer.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/executor/timer/Timer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/executor/timer/TimerTask.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/executor/timer/TimerTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/master/AbstractMasterService.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/master/AbstractMasterService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/master/ConfigChangeEvent.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/master/ConfigChangeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/master/ConfigListener.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/master/ConfigListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/master/ConfigService.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/master/ConfigService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/master/MasterService.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/master/MasterService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/master/NotifyListener.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/master/NotifyListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/master/RegionMasterService.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/master/RegionMasterService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/master/SubscribeRequest.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/master/SubscribeRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/monitor/HarvestTask.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/monitor/HarvestTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/monitor/HarvestTaskManager.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/monitor/HarvestTaskManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/monitor/MonitorConfig.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/monitor/MonitorConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/monitor/MonitorReportService.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/monitor/MonitorReportService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/monitor/MonitorReportServiceImpl.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/monitor/MonitorReportServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/monitor/TransferData.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/monitor/TransferData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/trace/TraceReportServiceImpl.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/trace/TraceReportServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/transfer/AbstractInvokerService.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/transfer/AbstractInvokerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/transfer/InvokerService.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/transfer/InvokerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/transfer/TransferInvokerService.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/transfer/TransferInvokerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/transfer/circuit/ReportCircuitBreaker.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/transfer/circuit/ReportCircuitBreaker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/transfer/dto/HeartBeatRequest.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/transfer/dto/HeartBeatRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/transfer/dto/HeartBeatResult.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/transfer/dto/HeartBeatResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/transfer/dto/RegisterRequest.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/transfer/dto/RegisterRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/transfer/dto/RegisterResult.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/transfer/dto/RegisterResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/transfer/dto/Result.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/transfer/dto/Result.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/transfer/dto/heartbeat/HeartbeatMessage.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/transfer/dto/heartbeat/HeartbeatMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/update/UpdateThread.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/update/UpdateThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/utils/AgentPath.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/utils/AgentPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/utils/ClassLoaderUtils.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/utils/ClassLoaderUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/utils/HttpClientUtil.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/utils/HttpClientUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/utils/MyConnectionSocketFactory.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/utils/MyConnectionSocketFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/utils/MySSLConnectionSocketFactory.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/utils/MySSLConnectionSocketFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/utils/NetworkUtil.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/utils/NetworkUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/utils/ReportDataBuilder.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/core/utils/ReportDataBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/Constants.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/Address.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/Address.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/Body.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/Body.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/HMacAlgorithm.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/HMacAlgorithm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/HMacSignatureUtil.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/HMacSignatureUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/Header.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/Header.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/Message.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/Message.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/MessageIdGenerator.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/MessageIdGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/MessageType.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/MessageType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/MessageWrapper.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/MessageWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/inbound/CommonResponse.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/inbound/CommonResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/inbound/EventDataBody.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/inbound/EventDataBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/inbound/EventDataHeader.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/inbound/EventDataHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/inbound/EventDataRequest.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/inbound/EventDataRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/inbound/EventDataResponse.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/inbound/EventDataResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/inbound/MonitorDataBody.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/inbound/MonitorDataBody.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/inbound/MonitorDataHeader.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/inbound/MonitorDataHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/inbound/MonitorDataRequest.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/inbound/MonitorDataRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/inbound/MonitorDataResponse.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/inbound/MonitorDataResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/outbound/CollectorStatusRequest.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/outbound/CollectorStatusRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/outbound/CollectorStatusResponse.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/outbound/CollectorStatusResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/outbound/SessionOpenRequest.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/outbound/SessionOpenRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/trace/ErrorType.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/trace/ErrorType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/trace/MonitorItemRow.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/trace/MonitorItemRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/trace/SpanEventExtend.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/trace/SpanEventExtend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/trace/SpanEventReport.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/trace/SpanEventReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/trace/SpanInfo.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/trace/SpanInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/trace/SpanInfoBuilder.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/trace/SpanInfoBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/trace/TraceInfo.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/access/trace/TraceInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/enums/AddressScope.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/enums/AddressScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/enums/AddressType.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/enums/AddressType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/enums/HttpMethod.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/enums/HttpMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/enums/Protocol.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/enums/Protocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/enums/SignatureAlgorithm.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/enums/SignatureAlgorithm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/exception/JavaagentRuntimeException.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/exception/JavaagentRuntimeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/exception/ShouldNotHappenException.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/exception/ShouldNotHappenException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/ClientManager.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/ClientManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/http/AbstractHttpSinger.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/http/AbstractHttpSinger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/http/AbstractSigner.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/http/AbstractSigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/http/HttpRequest.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/http/HttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/http/HttpSigner.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/http/HttpSigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/http/Request.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/http/Request.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/http/Singer.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/http/Singer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/netty/client/ClientHandler.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/netty/client/ClientHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/netty/client/NettyClient.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/netty/client/NettyClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/netty/client/NettyClientFactory.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/netty/client/NettyClientFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/netty/client/Sender.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/netty/client/Sender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/netty/client/ThreadPools.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/netty/client/ThreadPools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/netty/common/BaseHandler.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/netty/common/BaseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/websocket/ConnectConfig.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/websocket/ConnectConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/websocket/LubanWebSocketClient.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/websocket/LubanWebSocketClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/websocket/SecureWebSocketClient.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/websocket/SecureWebSocketClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/websocket/UnSecureWebSocketClient.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/websocket/UnSecureWebSocketClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/websocket/WebSocketFactory.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/websocket/WebSocketFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/websocket/future/FutureManagementService.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/websocket/future/FutureManagementService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/websocket/future/MessageFuture.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/transport/websocket/future/MessageFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/utils/APMThreadFactory.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/utils/APMThreadFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/utils/BinaryUtils.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/utils/BinaryUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/utils/GzipUtils.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/utils/GzipUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/utils/HttpUtils.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/utils/HttpUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/utils/JSON.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/utils/JSON.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/utils/StringUtil.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/utils/StringUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/utils/TimeUtil.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/utils/TimeUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/utils/UriUtil.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/lubanops/integration/utils/UriUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/plugin/PluginManager.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/plugin/PluginManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/plugin/classloader/PluginClassLoader.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/plugin/classloader/PluginClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/plugin/common/PluginConstant.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/plugin/common/PluginConstant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/plugin/config/AliaConfig.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/plugin/config/AliaConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/plugin/config/PluginConfig.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/plugin/config/PluginConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/plugin/config/PluginConfigManager.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/plugin/config/PluginConfigManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/plugin/config/PluginSetting.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/plugin/config/PluginSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/plugin/service/PluginService.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/plugin/service/PluginService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/plugin/service/PluginServiceManager.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/plugin/service/PluginServiceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/BaseService.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/BaseService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/Config.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/DynamicConfigurationFactoryServiceImpl.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/DynamicConfigurationFactoryServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/KieDynamicConfigurationServiceImpl.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/KieDynamicConfigurationServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/AbstractClient.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/AbstractClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/Client.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/ClientUrlManager.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/ClientUrlManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/http/DefaultHttpClient.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/http/DefaultHttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/http/HttpClient.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/http/HttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/http/HttpResult.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/http/HttpResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/kie/KieClient.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/kie/KieClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/kie/KieConfigEntity.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/kie/KieConfigEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/kie/KieListenerWrapper.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/kie/KieListenerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/kie/KieRequest.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/kie/KieRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/kie/KieResponse.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/kie/KieResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/kie/KieSubscriber.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/kie/KieSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/kie/ResultHandler.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/client/kie/ResultHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/constants/KieConstants.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/constants/KieConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/listener/KvDataHolder.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/listener/KvDataHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/selector/SelectStrategy.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/selector/SelectStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/selector/Selector.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/selector/Selector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/selector/url/UrlSelector.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/kie/selector/url/UrlSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/nop/NopDynamicConfigurationService.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/nop/NopDynamicConfigurationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/service/ConfigChangeType.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/service/ConfigChangeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/service/ConfigChangedEvent.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/service/ConfigChangedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/service/ConfigurationListener.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/service/ConfigurationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/service/DynamicConfigType.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/service/DynamicConfigType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/service/DynamicConfigurationFactoryService.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/service/DynamicConfigurationFactoryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/service/DynamicConfigurationService.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/service/DynamicConfigurationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/utils/LabelGroupUtils.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/utils/LabelGroupUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/zookeeper/ZookeeperDynamicConfigurationService.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/dynamicconfig/zookeeper/ZookeeperDynamicConfigurationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/heartbeat/ExtInfoProvider.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/heartbeat/ExtInfoProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/heartbeat/HeartbeatConfig.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/heartbeat/HeartbeatConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/heartbeat/HeartbeatService.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/heartbeat/HeartbeatService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/heartbeat/HeartbeatServiceImpl.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/heartbeat/HeartbeatServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/send/GatewayClient.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/send/GatewayClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/send/NettyGatewayClient.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/service/send/NettyGatewayClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/util/Assert.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/util/Assert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/util/CollectionUtils.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/util/CollectionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/util/FieldUtil.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/util/FieldUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/util/JarFileUtil.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/util/JarFileUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/util/PathUtils.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/util/PathUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/util/SpiLoadUtil.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/util/SpiLoadUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/util/StringUtils.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/util/StringUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/util/URIUtils.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/main/java/com/huawei/javamesh/core/util/URIUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/test/java/com/huawei/javamesh/core/lubanops/integration/authorization/HttpSignerTest.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/test/java/com/huawei/javamesh/core/lubanops/integration/authorization/HttpSignerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/test/java/com/huawei/javamesh/core/lubanops/integration/netty/NettyClientTest.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/test/java/com/huawei/javamesh/core/lubanops/integration/netty/NettyClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/test/java/com/huawei/javamesh/core/service/dynamicconfig/DynamicConfigurationFactoryServiceImplTest.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/test/java/com/huawei/javamesh/core/service/dynamicconfig/DynamicConfigurationFactoryServiceImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/test/java/com/huawei/javamesh/core/service/dynamicconfig/DynamicConfigurationSwitchTest.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/test/java/com/huawei/javamesh/core/service/dynamicconfig/DynamicConfigurationSwitchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/test/java/com/huawei/javamesh/core/service/dynamicconfig/KieDynamicConfigurationServiceImplTest.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/test/java/com/huawei/javamesh/core/service/dynamicconfig/KieDynamicConfigurationServiceImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/test/java/com/huawei/javamesh/core/service/dynamicconfig/kie/LabelGroupUtilsTest.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/test/java/com/huawei/javamesh/core/service/dynamicconfig/kie/LabelGroupUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-core/src/test/java/com/huawei/javamesh/core/service/dynamicconfig/kie/PublishTest.java
+++ b/javamesh-agentcore/javamesh-agentcore-core/src/test/java/com/huawei/javamesh/core/service/dynamicconfig/kie/PublishTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.huawei.javamesh.core.service.dynamicconfig.kie;

--- a/javamesh-agentcore/javamesh-agentcore-premain/src/main/java/com/huawei/javamesh/premain/AgentPremain.java
+++ b/javamesh-agentcore/javamesh-agentcore-premain/src/main/java/com/huawei/javamesh/premain/AgentPremain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-premain/src/main/java/com/huawei/javamesh/premain/common/BootArgsBuilder.java
+++ b/javamesh-agentcore/javamesh-agentcore-premain/src/main/java/com/huawei/javamesh/premain/common/BootArgsBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-premain/src/main/java/com/huawei/javamesh/premain/common/PathDeclarer.java
+++ b/javamesh-agentcore/javamesh-agentcore-premain/src/main/java/com/huawei/javamesh/premain/common/PathDeclarer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-premain/src/main/java/com/huawei/javamesh/premain/exception/DupPremainException.java
+++ b/javamesh-agentcore/javamesh-agentcore-premain/src/main/java/com/huawei/javamesh/premain/exception/DupPremainException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-agentcore/javamesh-agentcore-premain/src/main/java/com/huawei/javamesh/premain/exception/InitPremainException.java
+++ b/javamesh-agentcore/javamesh-agentcore-premain/src/main/java/com/huawei/javamesh/premain/exception/InitPremainException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/NettyServerApplication.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/NettyServerApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/common/conf/KafkaConf.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/common/conf/KafkaConf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/common/exception/ErrorMsgParser.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/common/exception/ErrorMsgParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/common/exception/KafkaTopicException.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/common/exception/KafkaTopicException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/common/handler/BaseHandler.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/common/handler/BaseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/common/util/GzipUtils.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/common/util/GzipUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/Address.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/Address.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/AddressScope.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/AddressScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/AddressType.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/AddressType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/AgentInfo.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/AgentInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/HeartBeatResult.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/HeartBeatResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/MonitorItem.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/MonitorItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/PluginInfo.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/PluginInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/Protocol.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/Protocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/RegisterResult.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/RegisterResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/Result.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/entity/Result.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/kafka/KafkaConsumerManager.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/kafka/KafkaConsumerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/kafka/KafkaProducerManager.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/kafka/KafkaProducerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/server/NettyServer.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/server/NettyServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/server/ServerHandler.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/server/ServerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/Config.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/DynamicConfigurationFactoryServiceImpl.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/DynamicConfigurationFactoryServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/KieDynamicConfigurationServiceImpl.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/KieDynamicConfigurationServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/AbstractClient.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/AbstractClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/Client.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/ClientUrlManager.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/ClientUrlManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/http/DefaultHttpClient.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/http/DefaultHttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/http/HttpClient.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/http/HttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/http/HttpResult.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/http/HttpResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/KieClient.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/KieClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/KieConfigEntity.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/KieConfigEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/KieListenerWrapper.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/KieListenerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/KieRequest.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/KieRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/KieResponse.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/KieResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/KieSubscriber.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/KieSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/ResultHandler.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/client/kie/ResultHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/constants/KieConstants.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/constants/KieConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/listener/KvDataHolder.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/listener/KvDataHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/listener/SubscriberManager.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/listener/SubscriberManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/selector/SelectStrategy.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/selector/SelectStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/selector/Selector.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/selector/Selector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/selector/url/UrlSelector.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/kie/selector/url/UrlSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/nop/NopDynamicConfigurationService.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/nop/NopDynamicConfigurationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/service/ConfigChangeType.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/service/ConfigChangeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/service/ConfigChangedEvent.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/service/ConfigChangedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/service/ConfigurationListener.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/service/ConfigurationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/service/DynamicConfigType.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/service/DynamicConfigType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/service/DynamicConfigurationFactoryService.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/service/DynamicConfigurationFactoryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/service/DynamicConfigurationService.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/service/DynamicConfigurationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/utils/LabelGroupUtils.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/utils/LabelGroupUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/zookeeper/ZookeeperDynamicConfigurationService.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/service/dynamicconfig/zookeeper/ZookeeperDynamicConfigurationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-backend/src/main/java/com/huawei/javamesh/backend/util/RandomUtil.java
+++ b/javamesh-backend/src/main/java/com/huawei/javamesh/backend/util/RandomUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-package/bin/append.bat
+++ b/javamesh-package/bin/append.bat
@@ -1,6 +1,6 @@
 @echo off
 
-@rem Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+@rem Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
 @rem
 @rem Licensed under the Apache License, Version 2.0 (the "License");
 @rem you may not use this file except in compliance with the License.

--- a/javamesh-package/bin/append.sh
+++ b/javamesh-package/bin/append.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+# Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/javamesh-package/resources/third-party-license.ftl
+++ b/javamesh-package/resources/third-party-license.ftl
@@ -1,6 +1,6 @@
 <#--
   #%L
-  Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+  Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
   %%
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-application/src/main/java/com/huawei/example/demo/DemoApplication.java
+++ b/javamesh-plugins/javamesh-example/demo-application/src/main/java/com/huawei/example/demo/DemoApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-application/src/main/java/com/huawei/example/demo/service/DemoAnnotation.java
+++ b/javamesh-plugins/javamesh-example/demo-application/src/main/java/com/huawei/example/demo/service/DemoAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-application/src/main/java/com/huawei/example/demo/service/DemoAnnotationService.java
+++ b/javamesh-plugins/javamesh-example/demo-application/src/main/java/com/huawei/example/demo/service/DemoAnnotationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-application/src/main/java/com/huawei/example/demo/service/DemoInterface.java
+++ b/javamesh-plugins/javamesh-example/demo-application/src/main/java/com/huawei/example/demo/service/DemoInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-application/src/main/java/com/huawei/example/demo/service/DemoNameService.java
+++ b/javamesh-plugins/javamesh-example/demo-application/src/main/java/com/huawei/example/demo/service/DemoNameService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-application/src/main/java/com/huawei/example/demo/service/DemoSuperTypeService.java
+++ b/javamesh-plugins/javamesh-example/demo-application/src/main/java/com/huawei/example/demo/service/DemoSuperTypeService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-application/src/main/java/com/huawei/example/demo/service/DemoTraceService.java
+++ b/javamesh-plugins/javamesh-example/demo-application/src/main/java/com/huawei/example/demo/service/DemoTraceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/common/DemoLogger.java
+++ b/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/common/DemoLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/config/DemoConfig.java
+++ b/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/config/DemoConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/config/DemoPojo.java
+++ b/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/config/DemoPojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/config/DemoType.java
+++ b/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/config/DemoType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/definition/DemoAnnotationDefinition.java
+++ b/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/definition/DemoAnnotationDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/definition/DemoBootstrapDefinition.java
+++ b/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/definition/DemoBootstrapDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/definition/DemoNameDefinition.java
+++ b/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/definition/DemoNameDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/definition/DemoSuperTypeDefinition.java
+++ b/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/definition/DemoSuperTypeDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/definition/DemoTraceDefinition.java
+++ b/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/definition/DemoTraceDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/interceptor/DemoConfigInterceptor.java
+++ b/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/interceptor/DemoConfigInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/interceptor/DemoConstInterceptor.java
+++ b/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/interceptor/DemoConstInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/interceptor/DemoInstInterceptor.java
+++ b/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/interceptor/DemoInstInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/interceptor/DemoServiceInterceptor.java
+++ b/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/interceptor/DemoServiceInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/interceptor/DemoStaticInterceptor.java
+++ b/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/interceptor/DemoStaticInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/interceptor/DemoTraceInterceptor.java
+++ b/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/interceptor/DemoTraceInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/service/DemoComplexService.java
+++ b/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/service/DemoComplexService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/service/DemoDynaConfService.java
+++ b/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/service/DemoDynaConfService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/service/DemoHeartBeatService.java
+++ b/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/service/DemoHeartBeatService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/service/DemoSimpleService.java
+++ b/javamesh-plugins/javamesh-example/demo-plugin/src/main/java/com/huawei/example/demo/service/DemoSimpleService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-service/src/main/java/com/huawei/example/demo/config/DemoServiceConfig.java
+++ b/javamesh-plugins/javamesh-example/demo-service/src/main/java/com/huawei/example/demo/config/DemoServiceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-example/demo-service/src/main/java/com/huawei/example/demo/service/DemoComplexServiceImpl.java
+++ b/javamesh-plugins/javamesh-example/demo-service/src/main/java/com/huawei/example/demo/service/DemoComplexServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-demos/flowcontrol-demo-cse/src/main/java/com/huawei/flowcontrol/demo/FlowControlDemoApplication.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-demos/flowcontrol-demo-cse/src/main/java/com/huawei/flowcontrol/demo/FlowControlDemoApplication.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-demos/flowcontrol-demo/src/main/java/com/huawei/flowcontrol/demo/FlowControlDemoApplication.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-demos/flowcontrol-demo/src/main/java/com/huawei/flowcontrol/demo/FlowControlDemoApplication.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-demos/pom.xml
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-demos/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+  ~ Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/DispatcherServletDefinition.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/DispatcherServletDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/DispatcherServletInterceptor.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/DispatcherServletInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/ResolverManager.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/ResolverManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/RuleSyncer.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/RuleSyncer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/constants/CseConstants.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/constants/CseConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/converter/Converter.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/converter/Converter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/converter/YamlConverter.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/converter/YamlConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/datasource/CseDataSourceManager.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/datasource/CseDataSourceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/datasource/CseKieDataSource.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/datasource/CseKieDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/enhancer/KieConfigurationEnhancer.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/enhancer/KieConfigurationEnhancer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/enhancer/ServiceCombServiceMetaEnhancer.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/enhancer/ServiceCombServiceMetaEnhancer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/entity/CseServiceMeta.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/entity/CseServiceMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/interceptors/KieConfigurationInterceptor.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/interceptors/KieConfigurationInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/interceptors/MetricServiceMetaInterceptor.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/interceptors/MetricServiceMetaInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/MatchGroupResolver.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/MatchGroupResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/MatchManager.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/MatchManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/Matcher.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/Matcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/operator/OperatorManager.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/match/operator/OperatorManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/AbstractResolver.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/AbstractResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/BulkheadRuleResolver.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/BulkheadRuleResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/CircuitBreakerRuleResolver.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/CircuitBreakerRuleResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/RateLimitingRuleResolver.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/RateLimitingRuleResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/Resolver.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/Resolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/RetryResolver.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/RetryResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/listener/ConfigUpdateListener.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/resolver/listener/ConfigUpdateListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/AbstractRule.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/AbstractRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/BulkheadRule.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/BulkheadRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/CircuitBreakerRule.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/CircuitBreakerRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/RateLimitingRule.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/RateLimitingRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/RetryRule.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/RetryRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/Rule.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/Rule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/isolate/IsolateThreadException.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/isolate/IsolateThreadException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/isolate/IsolateThreadRule.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/adapte/cse/rule/isolate/IsolateThreadRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/config/CommonConst.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/config/CommonConst.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/FlowControlThreadFactory.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/FlowControlThreadFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/config/CommonConst.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/config/CommonConst.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/config/ConfigConst.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/config/ConfigConst.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/config/FlowControlConfig.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/config/FlowControlConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/config/KafkaConnectBySslSwitch.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/config/KafkaConnectBySslSwitch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/config/KafkaConst.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/config/KafkaConst.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/DataSourceManager.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/DataSourceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/DataSourceUpdateSupport.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/DataSourceUpdateSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/DefaultDataSource.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/DefaultDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/DefaultDataSourceManager.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/DefaultDataSourceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/KieAutoRefreshDataSource.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/KieAutoRefreshDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/RuleCenter.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/RuleCenter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/RuleWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/RuleWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/authority/AuthorityRuleWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/authority/AuthorityRuleWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/degrade/DegradeRuleWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/degrade/DegradeRuleWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/flow/FlowRuleWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/flow/FlowRuleWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/isolate/IsolateThreadRuleWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/isolate/IsolateThreadRuleWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/system/SystemRuleWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/rule/system/SystemRuleWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/util/KieConfigClient.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/util/KieConfigClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/util/response/KieConfigItem.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/util/response/KieConfigItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/util/response/KieConfigLabels.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/util/response/KieConfigLabels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/util/response/KieConfigResponse.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/kie/util/response/KieConfigResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/zookeeper/ZookeeperCoreDataSource.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/zookeeper/ZookeeperCoreDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/zookeeper/ZookeeperDatasourceManager.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/datasource/zookeeper/ZookeeperDatasourceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/heartbeat/HeartbeatMessage.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/heartbeat/HeartbeatMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/heartbeat/KafkaHeartbeatSender.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/heartbeat/KafkaHeartbeatSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/init/InitExecutor.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/init/InitExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/init/InitRuleRedis.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/init/InitRuleRedis.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/metric/AbstractMetricSender.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/metric/AbstractMetricSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/metric/MetricSendWay.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/metric/MetricSendWay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/metric/MetricSender.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/metric/MetricSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/metric/NettyMetricSender.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/metric/NettyMetricSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/metric/SimpleKafkaMetricSender.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/metric/SimpleKafkaMetricSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/metric/provider/DefaultMetricProvider.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/metric/provider/DefaultMetricProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/metric/provider/MetricEntity.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/metric/provider/MetricEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/metric/provider/MetricProvider.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/metric/provider/MetricProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/DataSourceInitUtils.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/DataSourceInitUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/KafkaProducerEnum.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/KafkaProducerEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/KafkaProducerUtil.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/KafkaProducerUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/PluginConfigUtil.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/PluginConfigUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/RedisClient.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/RedisClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/RedisRuleUtil.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/RedisRuleUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/ZookeeperConnectionEnum.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/core/util/ZookeeperConnectionEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/entry/EntryFacade.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/entry/EntryFacade.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/exception/FlowControlException.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/exception/FlowControlException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/service/FlowControlServiceImpl.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/service/FlowControlServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/util/FilterUtil.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/util/FilterUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/util/SentinelRuleUtil.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/util/SentinelRuleUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/util/StringUtils.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/util/StringUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/util/TraceEntryUtils.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/java/com/huawei/flowcontrol/util/TraceEntryUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/resources/META-INF/services/com.alibaba.csp.sentinel.slotchain.ProcessorSlot
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/resources/META-INF/services/com.alibaba.csp.sentinel.slotchain.ProcessorSlot
@@ -1,5 +1,5 @@
 #
-# Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+# Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
 #
 
 com.huawei.flowcontrol.adapte.cse.rule.isolate.IsolateThreadSlot

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/resources/META-INF/services/com.huawei.flowcontrol.adapte.cse.match.operator.Operator
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/resources/META-INF/services/com.huawei.flowcontrol.adapte.cse.match.operator.Operator
@@ -1,5 +1,5 @@
 #
-# Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+# Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
 #
 
 com.huawei.flowcontrol.adapte.cse.match.operator.CompareOperator

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/resources/META-INF/services/com.huawei.flowcontrol.adapte.cse.resolver.AbstractResolver
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/main/resources/META-INF/services/com.huawei.flowcontrol.adapte.cse.resolver.AbstractResolver
@@ -1,5 +1,5 @@
 #
-# Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+# Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
 #
 com.huawei.flowcontrol.adapte.cse.match.MatchGroupResolver
 com.huawei.flowcontrol.adapte.cse.resolver.BulkheadRuleResolver

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/test/java/com/huawei/flowcontrol/adapte/cse/test/ResolverManagerTest.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/test/java/com/huawei/flowcontrol/adapte/cse/test/ResolverManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/test/java/com/huawei/flowcontrol/adapte/cse/test/RuleResolveTest.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/test/java/com/huawei/flowcontrol/adapte/cse/test/RuleResolveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/test/java/com/huawei/flowcontrol/adapte/cse/test/RuleSyncerTest.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-plugin/src/test/java/com/huawei/flowcontrol/adapte/cse/test/RuleSyncerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/DashboardApplication.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/DashboardApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/config/CasConfig.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/config/CasConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/config/RedisConfig.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/config/RedisConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/config/RedisSessionConfiguration.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/config/RedisSessionConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/controller/LoginController.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/controller/LoginController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/client/KieConfigClient.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/client/KieConfigClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/client/response/KieConfigItem.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/client/response/KieConfigItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/client/response/KieConfigLabel.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/client/response/KieConfigLabel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/client/response/KieConfigResponse.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/client/response/KieConfigResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/controller/KieDegradeControllerWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/controller/KieDegradeControllerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/controller/KieFlowControllerWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/controller/KieFlowControllerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/controller/KieParamFlowControllerWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/controller/KieParamFlowControllerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/controller/KieRuleCommonController.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/controller/KieRuleCommonController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/controller/KieSystemControllerWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/controller/KieSystemControllerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/discovery/KieServerDiscovery.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/discovery/KieServerDiscovery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/discovery/KieServerManagement.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/discovery/KieServerManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/discovery/SimpleKieDiscovery.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/discovery/SimpleKieDiscovery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/discovery/common/KieServerInfo.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/discovery/common/KieServerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/discovery/common/KieServerLabel.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/discovery/common/KieServerLabel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/exception/KieGeneralException.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/exception/KieGeneralException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/CommonKieRuleProvider.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/CommonKieRuleProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/CommonKieRulePublisher.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/CommonKieRulePublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/DegradeRuleCommonKiePublisher.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/DegradeRuleCommonKiePublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/DegradeRuleKieProvider.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/DegradeRuleKieProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/FlowRuleCommonKiePublisher.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/FlowRuleCommonKiePublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/FlowRuleKieProvider.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/FlowRuleKieProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/ParamFlowRuleCommonKiePublisher.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/ParamFlowRuleCommonKiePublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/ParamFlowRuleKieProvider.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/ParamFlowRuleKieProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/RuleKieProvider.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/RuleKieProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/RuleKiePublisher.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/RuleKiePublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/SystemRuleCommonKiePublisher.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/SystemRuleCommonKiePublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/SystemRuleKieProvider.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/operator/SystemRuleKieProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/util/KieConfig.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/util/KieConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/util/KieConfigUtil.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/kie/util/KieConfigUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/wrapper/DegradeControllerWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/wrapper/DegradeControllerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/wrapper/FlowControllerWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/wrapper/FlowControllerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/wrapper/ParamFlowControllerWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/wrapper/ParamFlowControllerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/wrapper/SystemControllerWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/wrapper/SystemControllerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/RuleZookeeperProvider.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/RuleZookeeperProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/RuleZookeeperPublisher.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/RuleZookeeperPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/ZookeeperConfig.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/ZookeeperConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/ZookeeperConfigUtil.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/ZookeeperConfigUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/controller/ZookeeperDegradeControllerWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/controller/ZookeeperDegradeControllerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/controller/ZookeeperFlowControllerWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/controller/ZookeeperFlowControllerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/controller/ZookeeperParamFlowRuleControllerWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/controller/ZookeeperParamFlowRuleControllerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/controller/ZookeeperSystemControllerWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/datasource/entity/rule/zookeeper/controller/ZookeeperSystemControllerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/discovery/RedisMachineDiscovery.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/discovery/RedisMachineDiscovery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/filter/LoginFilter.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/filter/LoginFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/filter/SafeHttpServletRequestWrapper.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/filter/SafeHttpServletRequestWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/rule/DynamicRuleProviderExt.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/rule/DynamicRuleProviderExt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/rule/DynamicRulePublisherExt.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/rule/DynamicRulePublisherExt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/util/DataType.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/util/DataType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/util/Md5Util.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/util/Md5Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/util/RedisUtil.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/util/RedisUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/util/SystemUtils.java
+++ b/javamesh-plugins/javamesh-flowcontrol/flowcontrol-server/src/main/java/com/huawei/flowcontrol/console/util/SystemUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/FlowrecordThreadFactory.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/FlowrecordThreadFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/config/CommonConst.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/config/CommonConst.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/config/ConfigConst.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/config/ConfigConst.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/config/CorrelationConst.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/config/CorrelationConst.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/config/FlowRecordConfig.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/config/FlowRecordConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/config/KafkaConst.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/config/KafkaConst.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/domain/HttpRequestEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/domain/HttpRequestEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/domain/HttpResponseEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/domain/HttpResponseEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/domain/MysqlRequestEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/domain/MysqlRequestEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/domain/RecordContext.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/domain/RecordContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/domain/RecordJob.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/domain/RecordJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/domain/RecordStatus.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/domain/RecordStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/domain/Recorder.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/domain/Recorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/init/InitListener.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/init/InitListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/init/RedissonProcessThreadPool.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/init/RedissonProcessThreadPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/init/RedissonThreadFactory.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/init/RedissonThreadFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/boot/BootInstrumentation.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/boot/BootInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/boot/BootInterceptor.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/boot/BootInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/custom/CustomInstanceMethodInterceptor.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/custom/CustomInstanceMethodInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/custom/CustomInstrumentation.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/custom/CustomInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/custom/CustomStaticMethodInterceptor.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/custom/CustomStaticMethodInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/http/v4/HttpServerInstrumentation.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/http/v4/HttpServerInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/http/v4/HttpServerInterceptor.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/http/v4/HttpServerInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/http/v4/RecordFlag.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/http/v4/RecordFlag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/redisson/v3/RedissonInstrumentation.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/redisson/v3/RedissonInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/redisson/v3/RedissonInterceptor.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/plugins/redisson/v3/RedissonInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/utils/AppNameUtil.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/utils/AppNameUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/utils/DubboUtil.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/utils/DubboUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/utils/PluginConfigUtil.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/utils/PluginConfigUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/utils/StringUtil.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-plugin/src/main/java/com/huawei/flowrecord/utils/StringUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/ConsoleApplication.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/ConsoleApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/controller/AppController.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/controller/AppController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/controller/JobController.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/controller/JobController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/elasticsearch/ElasticSearchIndicesInit.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/elasticsearch/ElasticSearchIndicesInit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/elasticsearch/ElasticsearchConfig.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/elasticsearch/ElasticsearchConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/elasticsearch/ElasticsearchJobStorage.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/elasticsearch/ElasticsearchJobStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/elasticsearch/ElasticsearchJobStorageImpl.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/elasticsearch/ElasticsearchJobStorageImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/elasticsearch/EsDataSource.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/elasticsearch/EsDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/elasticsearch/EsDataSourceAggregate.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/elasticsearch/EsDataSourceAggregate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/ModifyRuleEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/ModifyRuleEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/RecordJobEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/RecordJobEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/ReplayJobEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/ReplayJobEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/SubReplayJobEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/SubReplayJobEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/recordresult/RecordEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/recordresult/RecordEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/recordresult/RecordInterfaceCountEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/recordresult/RecordInterfaceCountEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/recordresult/RecordResultCountEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/recordresult/RecordResultCountEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/recordresult/RecordResultEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/recordresult/RecordResultEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/replayresult/IgnoreFieldEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/replayresult/IgnoreFieldEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/replayresult/ReplayInterfaceCountEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/replayresult/ReplayInterfaceCountEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/replayresult/ReplayResultCompareEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/replayresult/ReplayResultCompareEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/replayresult/ReplayResultCountEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/replayresult/ReplayResultCountEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/replayresult/ReplayResultDetailEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/replayresult/ReplayResultDetailEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/replayresult/ReplayResultEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/replayresult/ReplayResultEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/stresstest/FlowReplayMetric.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/stresstest/FlowReplayMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/stresstest/StressTestResult.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/entity/stresstest/StressTestResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/zookeeper/RecordJobPublisherExt.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/zookeeper/RecordJobPublisherExt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/zookeeper/RecordJobZookeeperPublisher.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/zookeeper/RecordJobZookeeperPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/zookeeper/ReplayJobPublisherExt.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/zookeeper/ReplayJobPublisherExt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/zookeeper/ReplayJobZookeeperPublisher.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/zookeeper/ReplayJobZookeeperPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/zookeeper/ZookeeperConfig.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/zookeeper/ZookeeperConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/zookeeper/ZookeeperUtil.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/datasource/zookeeper/ZookeeperUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/domain/CreateRecordJobRequest.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/domain/CreateRecordJobRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/domain/CreateReplayJobRequest.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/domain/CreateReplayJobRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/domain/QueryRecordJobRequest.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/domain/QueryRecordJobRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/domain/QueryReplayJobRequest.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/domain/QueryReplayJobRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/domain/RecordJobs.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/domain/RecordJobs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/domain/ReplayJobs.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/domain/ReplayJobs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/domain/Result.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/domain/Result.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/init/ElasticsearchIndicesInit.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/init/ElasticsearchIndicesInit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/init/RecordJobListener.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/init/RecordJobListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/init/RecordJobTimedTask.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/init/RecordJobTimedTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/init/ReplayJobListener.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/init/ReplayJobListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/job/JobPublisher.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/job/JobPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/disruptor/DisruptorConfig.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/disruptor/DisruptorConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/kafka/AbstractMessage.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/kafka/AbstractMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/kafka/HeartbeatMessage.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/kafka/HeartbeatMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/kafka/KafkaAdminClientConfig.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/kafka/KafkaAdminClientConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/kafka/KafkaConsumerConfig.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/kafka/KafkaConsumerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/kafka/MyConsumerRebalancerListener.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/kafka/MyConsumerRebalancerListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/kafka/TopicUtils.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/kafka/TopicUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/redis/JedisClusterPipeline.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/redis/JedisClusterPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/redis/JedisSlotAdvancedConnectionHandler.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/redis/JedisSlotAdvancedConnectionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/redis/RedisClusterCondition.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/redis/RedisClusterCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/redis/RedisConfig.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/redis/RedisConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/redis/RedisConn.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/redis/RedisConn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/redis/RedisConnCluster.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/redis/RedisConnCluster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/redis/RedisNode.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/redis/RedisNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/redis/RedisStandaloneCondition.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/redis/RedisStandaloneCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/redis/RedisUtil.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/redis/RedisUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/utils/CommonTools.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/utils/CommonTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/utils/RtcCoreConstants.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/common/utils/RtcCoreConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/consumer/HeartbeatDisruptorProducer.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/consumer/HeartbeatDisruptorProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/consumer/HeartbeatMessageHandler.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/consumer/HeartbeatMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/consumer/RtcConsumer.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/consumer/RtcConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/consumer/strategy/HeartbeatHandleStrategy.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/consumer/strategy/HeartbeatHandleStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/consumer/strategy/InterfaceTopicHandleStrategy.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/consumer/strategy/InterfaceTopicHandleStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/consumer/strategy/TopicHandleStrategyFactory.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/rtc/consumer/strategy/TopicHandleStrategyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/service/RecordResultService.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/service/RecordResultService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/service/ReplayResultService.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/service/ReplayResultService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/service/StressTestResultService.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/service/StressTestResultService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/util/Constant.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/util/Constant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/util/IPUtil.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/util/IPUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/util/MD5Util.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowre-console/src/main/java/com/huawei/flowrecordreplay/console/util/MD5Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/RecordConsoleApplication.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/RecordConsoleApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/config/CommonConfig.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/config/CommonConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/consumer/KafkaConsumerConfig.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/consumer/KafkaConsumerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/consumer/RecordConsoleConsumer.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/consumer/RecordConsoleConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/desensitization/DataDesensitize.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/desensitization/DataDesensitize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/desensitization/DataDesensitizeImpl.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/desensitization/DataDesensitizeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/elasticsearch/ElasticSearchImpl.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/elasticsearch/ElasticSearchImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/elasticsearch/ElasticSearchIndexCreator.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/elasticsearch/ElasticSearchIndexCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/entity/EntryRecordEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/entity/EntryRecordEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/entity/GroovyInfoEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/entity/GroovyInfoEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/entity/Recorder.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/entity/Recorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/entity/ReplaceRegexEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/entity/ReplaceRegexEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/entity/SubcallEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/entity/SubcallEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/netty/common/conf/KafkaConf.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/netty/common/conf/KafkaConf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/netty/common/constants/ProducerConstants.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/netty/common/constants/ProducerConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/netty/common/exception/ErrorMsgParser.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/netty/common/exception/ErrorMsgParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/netty/common/exception/KafkaTopicException.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/netty/common/exception/KafkaTopicException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/netty/common/handler/BaseHandler.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/netty/common/handler/BaseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/netty/common/util/GZipUtils.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/netty/common/util/GZipUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/netty/kafka/KafkaProducerManager.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/netty/kafka/KafkaProducerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/netty/server/NettyServer.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/netty/server/NettyServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/netty/server/ServerHandler.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/netty/server/ServerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/strategy/InterfaceTopicHandleStrategy.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/strategy/InterfaceTopicHandleStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/strategy/RecordConsolehandleStrategy.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/strategy/RecordConsolehandleStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/strategy/TopicHandleStrategyFactory.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/strategy/TopicHandleStrategyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/zookeeper/ZookeeperConfig.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/zookeeper/ZookeeperConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/zookeeper/ZookeeperUtil.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowrecord-console/src/main/java/com/huawei/recordconsole/zookeeper/ZookeeperUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/FlowReplayStarter.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/FlowReplayStarter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/config/Const.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/config/Const.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/config/FlowReplayConfig.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/config/FlowReplayConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/config/HttpClientConfig.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/config/HttpClientConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/config/KafkaConsumerConfig.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/config/KafkaConsumerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/config/KafkaProducerConfig.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/config/KafkaProducerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/config/ZookeeperConfig.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/config/ZookeeperConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/datasource/EsClient.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/datasource/EsClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/datasource/EsDataSource.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/datasource/EsDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/datasource/EsIndicesInit.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/datasource/EsIndicesInit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/Field.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/Field.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/FieldCompare.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/FieldCompare.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/FlowReplayMetric.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/FlowReplayMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/FlowReplayStatus.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/FlowReplayStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/IgnoreFieldEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/IgnoreFieldEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/ModifyRuleEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/ModifyRuleEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/RecordEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/RecordEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/ReplayResultEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/ReplayResultEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/SubReplayJobEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/SubReplayJobEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/SubReplayJobInfoEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/SubReplayJobInfoEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/content/DubboInvokeContent.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/content/DubboInvokeContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/content/HttpInvokeContent.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/content/HttpInvokeContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/message/DubboInvokeMessage.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/message/DubboInvokeMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/message/HttpInvokeMessage.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/message/HttpInvokeMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/message/ReplayResultMessage.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/message/ReplayResultMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/result/DubboRequestResult.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/result/DubboRequestResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/result/HttpRequestEntity.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/result/HttpRequestEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/result/HttpRequestResult.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/domain/result/HttpRequestResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/invocation/DubboReplayInvocationImpl.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/invocation/DubboReplayInvocationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/invocation/HttpReplayInvocationImpl.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/invocation/HttpReplayInvocationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/invocation/InvokeThread.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/invocation/InvokeThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/service/FlowReplayService.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/service/FlowReplayService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/service/FlowReplayWorker.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/service/FlowReplayWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/service/InvokeDataBuilder.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/service/InvokeDataBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/service/InvokeThread.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/service/InvokeThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/service/ResultCompareService.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/service/ResultCompareService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/utils/RpsCalculateUtil.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/utils/RpsCalculateUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/utils/WorkerStatusUtil.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/utils/WorkerStatusUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/utils/ZookeeperUtil.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/flowreplay/src/main/java/com/huawei/flowre/flowreplay/utils/ZookeeperUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/MockServerStarter.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/MockServerStarter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/config/MSConst.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/config/MSConst.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/config/ZookeeperConfig.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/config/ZookeeperConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/controller/MockController.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/controller/MockController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/datasource/EsClient.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/datasource/EsClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/datasource/EsDataSource.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/datasource/EsDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/domain/MockAction.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/domain/MockAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/domain/MockRequest.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/domain/MockRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/domain/MockRequestType.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/domain/MockRequestType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/domain/MockResult.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/domain/MockResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/domain/SelectResult.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/domain/SelectResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/service/MockResponseService.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/service/MockResponseService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/strategy/AbstractMockStrategy.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/strategy/AbstractMockStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/strategy/DefaultMockStrategy.java
+++ b/javamesh-plugins/javamesh-flowrecord/flowrecord-replay/mockserver/src/main/java/com/huawei/flowre/mockserver/strategy/DefaultMockStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/HerculesApplication.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/HerculesApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/config/ErrorPageRegistrarConfig.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/config/ErrorPageRegistrarConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/config/FeignRequestInterceptor.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/config/FeignRequestInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/config/FeignSupportConfig.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/config/FeignSupportConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/config/InfluxDBConfig.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/config/InfluxDBConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/config/WebSocketConfig.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/config/WebSocketConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/BaseController.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/BaseController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/LoginController.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/LoginController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/agent/AgentDownloadController.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/agent/AgentDownloadController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/agent/AgentManagerController.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/agent/AgentManagerController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/agent/AgentStatus.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/agent/AgentStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/agent/constant/AgentManagerType.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/agent/constant/AgentManagerType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/agent/constant/AgentPerformanceColumn.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/agent/constant/AgentPerformanceColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/agent/constant/DatabaseColumn.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/agent/constant/DatabaseColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/agent/constant/PerformanceResponseColumn.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/agent/constant/PerformanceResponseColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/agent/constant/ResponseColumn.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/agent/constant/ResponseColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/monitor/MonitorController.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/monitor/MonitorController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/monitor/MonitorModel.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/monitor/MonitorModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/monitor/dto/AgentRegistrationDTO.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/monitor/dto/AgentRegistrationDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/monitor/dto/MonitorHostDTO.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/monitor/dto/MonitorHostDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/monitor/dto/NetworkAddressDTO.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/monitor/dto/NetworkAddressDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/perftest/MonitorHostKey.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/perftest/MonitorHostKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/perftest/PerfTestController.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/perftest/PerfTestController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/perftest/TaskInfoKey.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/perftest/TaskInfoKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/perftest/TaskStatus.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/perftest/TaskStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/scenario/ScenarioController.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/scenario/ScenarioController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/script/ScriptController.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/script/ScriptController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/script/ScriptSorter.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/script/ScriptSorter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/script/ScriptType.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/script/ScriptType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/testreport/TestReportController.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/testreport/TestReportController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/websocket/WebSocketController.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/websocket/WebSocketController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/websocket/WebSocketEventHandler.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/websocket/WebSocketEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/websocket/WebSocketServer.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/controller/websocket/WebSocketServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/exception/HerculesException.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/exception/HerculesException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/exception/HerculesExceptionHandler.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/exception/HerculesExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/fallback/AgentDownLoadServiceFallbackFactory.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/fallback/AgentDownLoadServiceFallbackFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/fallback/AgentManagerServiceFallbackFactory.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/fallback/AgentManagerServiceFallbackFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/fallback/BaseFeignFallbackFactory.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/fallback/BaseFeignFallbackFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/fallback/HostAppMappingFallbackFactory.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/fallback/HostAppMappingFallbackFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/fallback/LoginServiceFallbackFactory.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/fallback/LoginServiceFallbackFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/fallback/PerfTestServiceFallbackFactory.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/fallback/PerfTestServiceFallbackFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/fallback/ScenarioServiceFallbackFactory.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/fallback/ScenarioServiceFallbackFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/fallback/ScriptServiceFallbackFactory.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/fallback/ScriptServiceFallbackFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/fallback/TestReportServiceFallbackFactory.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/fallback/TestReportServiceFallbackFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/ILoginService.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/ILoginService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/MyRequestInterceptor.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/MyRequestInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/agent/IAgentDownloadService.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/agent/IAgentDownloadService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/agent/IAgentManagerService.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/agent/IAgentManagerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/influxdb/CommonMonitorServiceImpl.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/influxdb/CommonMonitorServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/influxdb/IHostApplicationMapping.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/influxdb/IHostApplicationMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/influxdb/IMonitorService.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/influxdb/IMonitorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/influxdb/metric/tree/IMetricNode.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/influxdb/metric/tree/IMetricNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/influxdb/metric/tree/JvmType.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/influxdb/metric/tree/JvmType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/influxdb/metric/tree/MetricTreeBuilder.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/influxdb/metric/tree/MetricTreeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/influxdb/metric/tree/MetricType.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/influxdb/metric/tree/MetricType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/influxdb/metric/tree/impl/CommonMetricNode.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/influxdb/metric/tree/impl/CommonMetricNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/influxdb/query/IMetricQueryService.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/influxdb/query/IMetricQueryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/influxdb/query/InfluxDBSqlExecutor.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/influxdb/query/InfluxDBSqlExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/influxdb/query/MetricQueryServiceLoader.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/influxdb/query/MetricQueryServiceLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/influxdb/query/impl/CommonMetricQueryService.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/influxdb/query/impl/CommonMetricQueryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/perftest/IPerfTestService.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/perftest/IPerfTestService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/scenario/IScenarioService.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/scenario/IScenarioService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/script/IScriptService.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/script/IScriptService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/testreport/ITestReportService.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/service/testreport/ITestReportService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/util/DownloadUtils.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/util/DownloadUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/util/ListUtils.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-adaptation/src/main/java/com/huawei/hercules/util/ListUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-hercules/hercules-server/hercules-core/src/main/java/org/ngrinder/model/MonitoringHost.java
+++ b/javamesh-plugins/javamesh-hercules/hercules-server/hercules-core/src/main/java/org/ngrinder/model/MonitoringHost.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package org.ngrinder.model;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/config/Config.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/config/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.config;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/config/ConfigFactory.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/config/ConfigFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.config;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/config/Constant.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/config/Constant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.config;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/config/FileConfig.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/config/FileConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.config;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/config/bean/DataSourceInfo.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/config/bean/DataSourceInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.config.bean;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/config/bean/MongoSourceInfo.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/config/bean/MongoSourceInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.config.bean;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/config/bean/UserInfo.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/config/bean/UserInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.config.bean;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/core/Reflection.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/core/Reflection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.core;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/core/Tester.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/core/Tester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.core;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/factory/Shadow.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/factory/Shadow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.db.factory;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/factory/ShadowDruid.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/factory/ShadowDruid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.db.factory;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/factory/ShadowFactory.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/factory/ShadowFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.db.factory;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/factory/ShadowHikariDataSource.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/factory/ShadowHikariDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.db.factory;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/factory/ShadowTomcatDataSource.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/factory/ShadowTomcatDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.db.factory;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mongodb/MongoCollectionEnhance.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mongodb/MongoCollectionEnhance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.db.mongodb;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mongodb/MongoCollectionInterceptor.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mongodb/MongoCollectionInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.db.mongodb;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mongodb/MongoDatabaseEnhance.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mongodb/MongoDatabaseEnhance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.db.mongodb;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mongodb/MongoDatabaseInterceptor.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mongodb/MongoDatabaseInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.db.mongodb;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mongodb/ShadowMongodb.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mongodb/ShadowMongodb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.db.mongodb;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mybatis/MybatisEnhance.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mybatis/MybatisEnhance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.db.mybatis;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mybatis/MybatisInterceptor.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mybatis/MybatisInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.db.mybatis;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mybatis/ShadowDataSource.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/db/mybatis/ShadowDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.db.mybatis;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/http/AbstractHttpClientEnhance.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/http/AbstractHttpClientEnhance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.http;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/http/AsyncHttpClientEnhance.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/http/AsyncHttpClientEnhance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.http;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/http/HttpClientEnhance.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/http/HttpClientEnhance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.http;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/http/HttpClientInterceptor.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/http/HttpClientInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.http;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/kafka/ConsumerBuilder.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/kafka/ConsumerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.kafka;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/kafka/KafkaConsumerEnhance.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/kafka/KafkaConsumerEnhance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.kafka;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/kafka/KafkaConsumerInterceptor.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/kafka/KafkaConsumerInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.kafka;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/kafka/KafkaProducerEnhance.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/kafka/KafkaProducerEnhance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.kafka;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/kafka/KafkaProducerInterceptor.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/kafka/KafkaProducerInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.kafka;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/kafka/ShadowConsumer.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/kafka/ShadowConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.kafka;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/RedisUtils.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/RedisUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.redis;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/JedisClusterInterceptor.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/JedisClusterInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.redis.jedis;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/JedisKeyInterceptor.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/JedisKeyInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.redis.jedis;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/JedisPoolInterceptor.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/JedisPoolInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.redis.jedis;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/ShadowJedisFactory.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/ShadowJedisFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.redis.jedis;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/Handler.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/Handler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.redis.jedis.command;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/HandlerFactory.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/HandlerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.redis.jedis.command;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/ModifyAllParamsHandler.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/ModifyAllParamsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.redis.jedis.command;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/ModifyFirstParamHandler.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/ModifyFirstParamHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.redis.jedis.command;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/ModifyFirstTwoParamsHandler.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/ModifyFirstTwoParamsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.redis.jedis.command;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/ModifySkipValueHandler.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/ModifySkipValueHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.redis.jedis.command;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/NoopHandler.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/jedis/command/NoopHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.redis.jedis.command;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/lettuce/LettuceKeyInterceptor.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/lettuce/LettuceKeyInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.redis.lettuce;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/lettuce/LettucePoolInterceptor.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/lettuce/LettucePoolInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.redis.lettuce;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/lettuce/pool/GenericObjectPoolProxy.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/lettuce/pool/GenericObjectPoolProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.redis.lettuce.pool;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/lettuce/pool/SoftObjectPoolProxy.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/lettuce/pool/SoftObjectPoolProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.redis.lettuce.pool;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/RedissonClusterInterceptor.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/RedissonClusterInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.redis.redisson;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/RedissonKeyInterceptor.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/RedissonKeyInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.redis.redisson;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/RedissonObjectInterceptor.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/RedissonObjectInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.redis.redisson;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/RedissonUtils.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/RedissonUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.redis.redisson;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowClusterConfig.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowClusterConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.redis.redisson.config;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowConfig.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.redis.redisson.config;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowConfigChains.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowConfigChains.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.redis.redisson.config;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowMasterSlaveConfig.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowMasterSlaveConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.redis.redisson.config;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowReplicatedConfig.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowReplicatedConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.redis.redisson.config;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowSentinelConfig.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowSentinelConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.redis.redisson.config;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowSingleConfig.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/config/ShadowSingleConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.redis.redisson.config;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/workaround/RedissonLimiterDeleteInterceptor.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/workaround/RedissonLimiterDeleteInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.redis.redisson.workaround;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/workaround/RedissonShadowInterceptor.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/redis/redisson/workaround/RedissonShadowInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 package com.lubanops.stresstest.redis.redisson.workaround;
 

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/servlet/WebRequestEnhance.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/servlet/WebRequestEnhance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.servlet;

--- a/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/servlet/WebRequestInterceptor.java
+++ b/javamesh-plugins/javamesh-online-stresstest/online-stresstest-plugin/src/main/java/com/lubanops/stresstest/servlet/WebRequestInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2020-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 
 package com.lubanops.stresstest.servlet;

--- a/javamesh-plugins/javamesh-route/demo-route/demo-gray-dubbo/dubbo-a/src/main/java/com/huawei/dubbotest/DubboAApplication.java
+++ b/javamesh-plugins/javamesh-route/demo-route/demo-gray-dubbo/dubbo-a/src/main/java/com/huawei/dubbotest/DubboAApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/demo-route/demo-gray-dubbo/dubbo-a/src/main/java/com/huawei/dubbotest/controller/DubboController.java
+++ b/javamesh-plugins/javamesh-route/demo-route/demo-gray-dubbo/dubbo-a/src/main/java/com/huawei/dubbotest/controller/DubboController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/demo-route/demo-gray-dubbo/dubbo-b/src/main/java/com/huawei/dubbotest/service/DubboBApplication.java
+++ b/javamesh-plugins/javamesh-route/demo-route/demo-gray-dubbo/dubbo-b/src/main/java/com/huawei/dubbotest/service/DubboBApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/demo-route/demo-gray-dubbo/dubbo-b/src/main/java/com/huawei/dubbotest/service/imp/BTestImp.java
+++ b/javamesh-plugins/javamesh-route/demo-route/demo-gray-dubbo/dubbo-b/src/main/java/com/huawei/dubbotest/service/imp/BTestImp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/demo-route/demo-gray-dubbo/dubbo-b2/src/main/java/com/huawei/dubbotest/service/DubboBApplication.java
+++ b/javamesh-plugins/javamesh-route/demo-route/demo-gray-dubbo/dubbo-b2/src/main/java/com/huawei/dubbotest/service/DubboBApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/demo-route/demo-gray-dubbo/dubbo-b2/src/main/java/com/huawei/dubbotest/service/imp/BTestImp.java
+++ b/javamesh-plugins/javamesh-route/demo-route/demo-gray-dubbo/dubbo-b2/src/main/java/com/huawei/dubbotest/service/imp/BTestImp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/demo-route/demo-gray-dubbo/dubbo-demo-common/src/main/java/com/huawei/dubbotest/domain/Test.java
+++ b/javamesh-plugins/javamesh-route/demo-route/demo-gray-dubbo/dubbo-demo-common/src/main/java/com/huawei/dubbotest/domain/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/demo-route/demo-gray-dubbo/dubbo-demo-common/src/main/java/com/huawei/dubbotest/service/BTest.java
+++ b/javamesh-plugins/javamesh-route/demo-route/demo-gray-dubbo/dubbo-demo-common/src/main/java/com/huawei/dubbotest/service/BTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/AbstractInstDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/AbstractInstDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/apache/ClusterDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/apache/ClusterDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/apache/InterfaceConfigDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/apache/InterfaceConfigDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/apache/RegistryDirectoryDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/apache/RegistryDirectoryDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/servicecomb/RegistrationDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/definition/servicecomb/RegistrationDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/interceptor/apache/ClusterInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/interceptor/apache/ClusterInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/interceptor/apache/InterfaceConfigInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/interceptor/apache/InterfaceConfigInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/interceptor/apache/RegistryDirectoryInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/interceptor/apache/RegistryDirectoryInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/interceptor/servicecomb/RegistrationInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/interceptor/servicecomb/RegistrationInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/service/AbstractPluginService.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/service/AbstractPluginService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/service/InterfaceConfigService.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/service/InterfaceConfigService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/service/RegistrationService.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/service/RegistrationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/service/RegistryDirectoryService.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/java/com/huawei/gray/dubbo/service/RegistryDirectoryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/resources/META-INF/services/com.huawei.javamesh.core.agent.definition.EnhanceDefinition
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-plugin/src/main/resources/META-INF/services/com.huawei.javamesh.core.agent.definition.EnhanceDefinition
@@ -1,5 +1,5 @@
 #
-# Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+# Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
 #
 
 com.huawei.gray.dubbo.definition.apache.ClusterDefinition

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/cache/DubboCache.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/cache/DubboCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/service/ConfigServiceImpl.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/service/ConfigServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/service/InterfaceConfigServiceImpl.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/service/InterfaceConfigServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/service/RegistrationServiceImpl.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/service/RegistrationServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/service/RegistryDirectoryServiceImpl.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/service/RegistryDirectoryServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/InvokerChooser.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/InvokerChooser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/InvokerStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/InvokerStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/RuleStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/RuleStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/RuleStrategyEnum.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/RuleStrategyEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/TypeStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/TypeStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/TypeStrategyChooser.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/TypeStrategyChooser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/VersionChooser.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/VersionChooser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/VersionStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/VersionStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/invoker/NotMatchVersionsInvokerStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/invoker/NotMatchVersionsInvokerStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/invoker/TargetVersionInvokerStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/invoker/TargetVersionInvokerStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/rule/UpstreamRuleStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/rule/UpstreamRuleStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/rule/WeightRuleStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/rule/WeightRuleStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/type/ArrayTypeStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/type/ArrayTypeStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/type/EmptyTypeStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/type/EmptyTypeStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/type/EnabledTypeStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/type/EnabledTypeStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/type/ListTypeStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/type/ListTypeStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/type/MapTypeStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/type/MapTypeStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/type/ObjectTypeStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/type/ObjectTypeStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/version/MsgVersionStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/version/MsgVersionStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/version/UrlVersionStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/strategy/version/UrlVersionStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/utils/RouterUtil.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/java/com/huawei/gray/dubbo/utils/RouterUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/resources/META-INF/services/com.huawei.javamesh.core.plugin.service.PluginService
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/main/resources/META-INF/services/com.huawei.javamesh.core.plugin.service.PluginService
@@ -1,5 +1,5 @@
 #
-# Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+# Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
 #
 com.huawei.gray.dubbo.service.ConfigServiceImpl
 com.huawei.gray.dubbo.service.InterfaceConfigServiceImpl

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/test/java/com/huawei/gray/dubbo/strategy/TypeStrategyChooserTest.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/test/java/com/huawei/gray/dubbo/strategy/TypeStrategyChooserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/test/java/com/huawei/gray/dubbo/strategy/type/ArrayTypeStrategyTest.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/test/java/com/huawei/gray/dubbo/strategy/type/ArrayTypeStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/test/java/com/huawei/gray/dubbo/strategy/type/EmptyTypeStrategyTest.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/test/java/com/huawei/gray/dubbo/strategy/type/EmptyTypeStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/test/java/com/huawei/gray/dubbo/strategy/type/EnabledTypeStrategyTest.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/test/java/com/huawei/gray/dubbo/strategy/type/EnabledTypeStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/test/java/com/huawei/gray/dubbo/strategy/type/ListTypeStrategyTest.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/test/java/com/huawei/gray/dubbo/strategy/type/ListTypeStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/test/java/com/huawei/gray/dubbo/strategy/type/MapTypeStrategyTest.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/test/java/com/huawei/gray/dubbo/strategy/type/MapTypeStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/test/java/com/huawei/gray/dubbo/strategy/type/ObjectTypeStrategyTest.java
+++ b/javamesh-plugins/javamesh-route/gray-dubbo-2.7.x-service/src/test/java/com/huawei/gray/dubbo/strategy/type/ObjectTypeStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/LoadBalancerFeignClientDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/LoadBalancerFeignClientDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/register/EurekaClientRegisterDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/register/EurekaClientRegisterDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/register/NacosRegisterDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/register/NacosRegisterDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/register/ServiceCenterRegisterDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/register/ServiceCenterRegisterDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/register/ServiceCombRegisterDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/register/ServiceCombRegisterDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/register/ZookeeperRegisterDefinition.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/definition/register/ZookeeperRegisterDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/EurekaClientRegisterInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/EurekaClientRegisterInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/LoadBalancerClientInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/LoadBalancerClientInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/NacosRegisterInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/NacosRegisterInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/ServiceCenterRegisterInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/ServiceCenterRegisterInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/ServiceCombRegisterInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/ServiceCombRegisterInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/ZookeeperRegisterInterceptor.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/interceptor/ZookeeperRegisterInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/service/LoadBalancerClientService.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/service/LoadBalancerClientService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/service/RegisterService.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/java/com/huawei/gray/feign/service/RegisterService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/resources/META-INF/services/com.huawei.javamesh.core.agent.definition.EnhanceDefinition
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-plugin/src/main/resources/META-INF/services/com.huawei.javamesh.core.agent.definition.EnhanceDefinition
@@ -1,5 +1,5 @@
 #
-# Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+# Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
 #
 
 com.huawei.gray.feign.definition.register.EurekaClientRegisterDefinition

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/context/CurrentInstance.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/context/CurrentInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/context/HostContext.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/context/HostContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/rule/RuleStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/rule/RuleStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/rule/RuleType.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/rule/RuleType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/rule/UpstreamRuleStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/rule/UpstreamRuleStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/rule/WeightRuleStrategy.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/rule/WeightRuleStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/service/LoadBalancerClientServiceImpl.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/service/LoadBalancerClientServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/service/RegisterServiceImpl.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/service/RegisterServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/util/RouterUtil.java
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/java/com/huawei/gray/feign/util/RouterUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/resources/META-INF/services/com.huawei.javamesh.core.plugin.service.PluginService
+++ b/javamesh-plugins/javamesh-route/gray-feign-http-9.x-service/src/main/resources/META-INF/services/com.huawei.javamesh.core.plugin.service.PluginService
@@ -1,5 +1,5 @@
 #
-# Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+# Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
 #
 com.huawei.gray.feign.service.DefaultHttpClientServiceImpl
 com.huawei.gray.feign.service.LoadBalancerClientServiceImpl

--- a/javamesh-plugins/javamesh-route/pom.xml
+++ b/javamesh-plugins/javamesh-route/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+  ~ Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/javamesh-plugins/javamesh-route/route-common/pom.xml
+++ b/javamesh-plugins/javamesh-route/route-common/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+  ~ Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/factory/NamedThreadFactory.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/factory/NamedThreadFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/addr/AddrCache.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/addr/AddrCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/addr/entity/Addr.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/addr/entity/Addr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/addr/entity/Instances.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/addr/entity/Instances.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/addr/entity/Metadata.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/addr/entity/Metadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/config/GrayConfig.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/config/GrayConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/constants/GrayConstant.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/constants/GrayConstant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/LabelCache.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/LabelCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/CurrentTag.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/CurrentTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/GrayConfiguration.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/GrayConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/Match.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/Match.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/MatchRule.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/MatchRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/MatchStrategy.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/MatchStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/Route.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/Route.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/Rule.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/Rule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/Tags.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/Tags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/ValueMatch.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/ValueMatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/ValueMatchDeserializer.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/ValueMatchDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/VersionFrom.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/label/entity/VersionFrom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/listener/GrayConfigListener.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/listener/GrayConfigListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/ValueMatchStrategy.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/ValueMatchStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/ExactValueMatchStrategy.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/ExactValueMatchStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/GreaterValueMatchStrategy.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/GreaterValueMatchStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/InValueMatchStrategy.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/InValueMatchStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/LessValueMatchStrategy.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/LessValueMatchStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/NoEquValueMatchStrategy.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/NoEquValueMatchStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/NoGreaterValueMatchStrategy.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/NoGreaterValueMatchStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/NoLessValueMatchStrategy.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/NoLessValueMatchStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/PrefixValueMatchStrategy.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/PrefixValueMatchStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/RegexValueMatchStrategy.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/gray/strategy/match/RegexValueMatchStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/threadlocal/ThreadLocalContext.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/threadlocal/ThreadLocalContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/utils/CollectionUtils.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/java/com/huawei/route/common/utils/CollectionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-route/route-common/src/main/resources/META-INF/services/com.huawei.javamesh.core.plugin.config.PluginConfig
+++ b/javamesh-plugins/javamesh-route/route-common/src/main/resources/META-INF/services/com.huawei.javamesh.core.plugin.config.PluginConfig
@@ -1,5 +1,5 @@
 #
-# Copyright (c) Huawei Technologies Co., Ltd. 2021-2022. All rights reserved.
+# Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
 #
 
 com.huawei.route.common.gray.config.GrayConfig

--- a/javamesh-plugins/javamesh-route/route-common/src/test/java/com/huawei/route/common/gray/label/entity/MatchStrategyTest.java
+++ b/javamesh-plugins/javamesh-route/route-common/src/test/java/com/huawei/route/common/gray/label/entity/MatchStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/connection-pool-collect-plugin/src/main/java/com/huawei/javamesh/sample/connection/pool/collect/collector/DruidMetricCollector.java
+++ b/javamesh-plugins/javamesh-server-monitor/connection-pool-collect-plugin/src/main/java/com/huawei/javamesh/sample/connection/pool/collect/collector/DruidMetricCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/connection-pool-collect-plugin/src/main/java/com/huawei/javamesh/sample/connection/pool/collect/collector/DruidMetricProvider.java
+++ b/javamesh-plugins/javamesh-server-monitor/connection-pool-collect-plugin/src/main/java/com/huawei/javamesh/sample/connection/pool/collect/collector/DruidMetricProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/connection-pool-collect-plugin/src/main/java/com/huawei/javamesh/sample/connection/pool/collect/config/DruidMonitorConfig.java
+++ b/javamesh-plugins/javamesh-server-monitor/connection-pool-collect-plugin/src/main/java/com/huawei/javamesh/sample/connection/pool/collect/config/DruidMonitorConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/connection-pool-collect-plugin/src/main/java/com/huawei/javamesh/sample/connection/pool/collect/definition/DruidDataSourceStatManagerDefinition.java
+++ b/javamesh-plugins/javamesh-server-monitor/connection-pool-collect-plugin/src/main/java/com/huawei/javamesh/sample/connection/pool/collect/definition/DruidDataSourceStatManagerDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/connection-pool-collect-plugin/src/main/java/com/huawei/javamesh/sample/connection/pool/collect/interceptor/AddDataSourceInterceptor.java
+++ b/javamesh-plugins/javamesh-server-monitor/connection-pool-collect-plugin/src/main/java/com/huawei/javamesh/sample/connection/pool/collect/interceptor/AddDataSourceInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/connection-pool-collect-plugin/src/main/java/com/huawei/javamesh/sample/connection/pool/collect/interceptor/RemoveDataSourceInterceptor.java
+++ b/javamesh-plugins/javamesh-server-monitor/connection-pool-collect-plugin/src/main/java/com/huawei/javamesh/sample/connection/pool/collect/interceptor/RemoveDataSourceInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/connection-pool-collect-plugin/src/main/java/com/huawei/javamesh/sample/connection/pool/collect/service/DruidMonitorService.java
+++ b/javamesh-plugins/javamesh-server-monitor/connection-pool-collect-plugin/src/main/java/com/huawei/javamesh/sample/connection/pool/collect/service/DruidMonitorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/databasepeer-parse-service/src/main/java/com/huawei/javamesh/sample/databasepeerparse/service/DatabasePeerParseServiceImpl.java
+++ b/javamesh-plugins/javamesh-server-monitor/databasepeer-parse-service/src/main/java/com/huawei/javamesh/sample/databasepeerparse/service/DatabasePeerParseServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/MetricServerApplication.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/MetricServerApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/config/InfluxConfig.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/config/InfluxConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/config/InfluxdbFactory.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/config/InfluxdbFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/config/KafkaConfig.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/config/KafkaConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/controller/AgentRegistrationController.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/controller/AgentRegistrationController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/controller/CommonController.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/controller/CommonController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/controller/ConnectionPoolController.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/controller/ConnectionPoolController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/controller/IbmPoolController.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/controller/IbmPoolController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/controller/OpenJdkJvmController.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/controller/OpenJdkJvmController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/controller/ServerMetricController.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/controller/ServerMetricController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/InfluxDao.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/InfluxDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/common/FluxBuilder.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/common/FluxBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/common/FluxTableResolver.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/common/FluxTableResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/CommonMetricInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/CommonMetricInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/MemoryPoolInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/MemoryPoolInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/connectionpool/DataSourceInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/connectionpool/DataSourceInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/ibmpool/CSInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/ibmpool/CSInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/ibmpool/JCCInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/ibmpool/JCCInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/ibmpool/JDCInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/ibmpool/JDCInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/ibmpool/MNHSInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/ibmpool/MNHSInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/ibmpool/NAInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/ibmpool/NAInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/ibmpool/NSInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/ibmpool/NSInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/ibmpool/TLInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/ibmpool/TLInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/ibmpool/TSInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/ibmpool/TSInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/CpuInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/CpuInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/GCInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/GCInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/HeapMemoryInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/HeapMemoryInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/NonHeapMemoryInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/NonHeapMemoryInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/OldGCInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/OldGCInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/ThreadInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/ThreadInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/YoungGCInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/YoungGCInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/memorypool/CodeCacheInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/memorypool/CodeCacheInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/memorypool/MetaspaceInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/memorypool/MetaspaceInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/memorypool/NewGenInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/memorypool/NewGenInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/memorypool/OldGenInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/memorypool/OldGenInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/memorypool/PermGenInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/memorypool/PermGenInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/memorypool/SurvivorInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/openjdk/memorypool/SurvivorInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/servermonitor/CpuInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/servermonitor/CpuInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/servermonitor/MemoryInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/servermonitor/MemoryInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/servermonitor/NetworkInfluxEntity.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/entity/servermonitor/NetworkInfluxEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/request/InfluxInsertRequest.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/request/InfluxInsertRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/request/InfluxQueryRequest.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dao/influxdb/request/InfluxQueryRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/connectionpool/DataSourceDTO.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/connectionpool/DataSourceDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/ibmpool/IbmMemoryPoolDTO.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/ibmpool/IbmMemoryPoolDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/ibmpool/IbmPoolType.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/ibmpool/IbmPoolType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/openjdk/CpuDTO.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/openjdk/CpuDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/openjdk/GcDTO.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/openjdk/GcDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/openjdk/OpenJdkMemoryDTO.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/openjdk/OpenJdkMemoryDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/openjdk/OpenJdkMemoryPoolDTO.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/openjdk/OpenJdkMemoryPoolDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/openjdk/ThreadDTO.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/openjdk/ThreadDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/register/AgentRegistrationDTO.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/register/AgentRegistrationDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/register/NetworkAddressDTO.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/register/NetworkAddressDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/servermonitor/CpuDTO.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/servermonitor/CpuDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/servermonitor/DiskDTO.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/servermonitor/DiskDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/servermonitor/MemoryDTO.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/servermonitor/MemoryDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/servermonitor/NetworkDTO.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/dto/servermonitor/NetworkDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/kafka/AgentRegistrationKafkaReceiver.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/kafka/AgentRegistrationKafkaReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/kafka/ConnectionPoolKafkaReceiver.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/kafka/ConnectionPoolKafkaReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/kafka/IbmJvmMonitorKafkaReceiver.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/kafka/IbmJvmMonitorKafkaReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/kafka/OpenJdkJvmMonitorKafkaReceiver.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/kafka/OpenJdkJvmMonitorKafkaReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/kafka/ServerMonitorKafkaReceiver.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/kafka/ServerMonitorKafkaReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/service/AgentRegistrationService.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/service/AgentRegistrationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/service/CommonService.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/service/CommonService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/service/ConnectionPoolService.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/service/ConnectionPoolService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/service/IbmMemoryPoolService.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/service/IbmMemoryPoolService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/service/InfluxService.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/service/InfluxService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/service/OpenJdkJvmMetricService.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/service/OpenJdkJvmMetricService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/service/OpenJdkMemoryPoolService.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/service/OpenJdkMemoryPoolService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/service/OpenJdkMemoryService.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/service/OpenJdkMemoryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/service/ServerMetricService.java
+++ b/javamesh-plugins/javamesh-server-monitor/metric-server/src/main/java/com/huawei/javamesh/metricserver/service/ServerMetricService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/monitor-common/src/main/java/com/huawei/javamesh/sample/monitor/common/collect/CollectTask.java
+++ b/javamesh-plugins/javamesh-server-monitor/monitor-common/src/main/java/com/huawei/javamesh/sample/monitor/common/collect/CollectTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/monitor-common/src/main/java/com/huawei/javamesh/sample/monitor/common/collect/MetricProvider.java
+++ b/javamesh-plugins/javamesh-server-monitor/monitor-common/src/main/java/com/huawei/javamesh/sample/monitor/common/collect/MetricProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/monitor-common/src/main/java/com/huawei/javamesh/sample/monitor/common/config/ServiceConfig.java
+++ b/javamesh-plugins/javamesh-server-monitor/monitor-common/src/main/java/com/huawei/javamesh/sample/monitor/common/config/ServiceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/monitor-common/src/main/java/com/huawei/javamesh/sample/monitor/common/service/DatabasePeerParseService.java
+++ b/javamesh-plugins/javamesh-server-monitor/monitor-common/src/main/java/com/huawei/javamesh/sample/monitor/common/service/DatabasePeerParseService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/protocol/src/main/proto/AgentRegistration.proto
+++ b/javamesh-plugins/javamesh-server-monitor/protocol/src/main/proto/AgentRegistration.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 syntax = "proto3";
 

--- a/javamesh-plugins/javamesh-server-monitor/protocol/src/main/proto/ConnectionPoolMonitor.proto
+++ b/javamesh-plugins/javamesh-server-monitor/protocol/src/main/proto/ConnectionPoolMonitor.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 syntax = "proto3";
 

--- a/javamesh-plugins/javamesh-server-monitor/protocol/src/main/proto/IbmJvmMonitor.proto
+++ b/javamesh-plugins/javamesh-server-monitor/protocol/src/main/proto/IbmJvmMonitor.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 syntax = "proto3";
 

--- a/javamesh-plugins/javamesh-server-monitor/protocol/src/main/proto/ServerMonitor.proto
+++ b/javamesh-plugins/javamesh-server-monitor/protocol/src/main/proto/ServerMonitor.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved.
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  */
 syntax = "proto3";
 

--- a/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/collector/CpuMetricCollector.java
+++ b/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/collector/CpuMetricCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/collector/DiskMetricCollector.java
+++ b/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/collector/DiskMetricCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/collector/IbmJvmMetricCollector.java
+++ b/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/collector/IbmJvmMetricCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/collector/MemoryMetricCollector.java
+++ b/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/collector/MemoryMetricCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/collector/NetworkMetricCollector.java
+++ b/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/collector/NetworkMetricCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/command/Command.java
+++ b/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/command/Command.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/command/CommandExecutor.java
+++ b/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/command/CommandExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/command/CommonMonitorCommand.java
+++ b/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/command/CommonMonitorCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/command/CpuCommand.java
+++ b/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/command/CpuCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/command/DiskCommand.java
+++ b/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/command/DiskCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/command/MemoryCommand.java
+++ b/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/command/MemoryCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/command/MonitorCommand.java
+++ b/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/command/MonitorCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/command/NetworkCommand.java
+++ b/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/command/NetworkCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/common/CalculateUtil.java
+++ b/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/common/CalculateUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/common/CheckIBMParameter.java
+++ b/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/common/CheckIBMParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/common/Constant.java
+++ b/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/common/Constant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/common/StreamHandler.java
+++ b/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/common/StreamHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/common/VoidStreamHandler.java
+++ b/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/common/VoidStreamHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/config/ServerMonitorConfig.java
+++ b/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/config/ServerMonitorConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/provider/IbmJvmMetricProvider.java
+++ b/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/provider/IbmJvmMetricProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/provider/ServerMonitorMetricProvider.java
+++ b/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/provider/ServerMonitorMetricProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/service/MonitorService.java
+++ b/javamesh-plugins/javamesh-server-monitor/server-monitor-service/src/main/java/com/huawei/javamesh/sample/servermonitor/service/MonitorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) Huawei Technologies Co., Ltd. 2021-2021. All rights reserved
+ * Copyright (C) 2021-2021 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
【需求单号】#231

【修改内容】修正huawei copyright的时间与公司的顺序，与NOTICE文件保持一致
相关参考链接如下：
https://www.apache.org/licenses/LICENSE-2.0.html apache license 2.0关于header的建议
https://source.android.com/setup/contribute/code-style#use-javadoc-standard-comments google安卓开源手册中javadoc部分

【用例描述】不涉及

【自测情况】不涉及

【影响范围】所有header